### PR TITLE
Cleaning intermediate files

### DIFF
--- a/MultiFQtoVC.nf
+++ b/MultiFQtoVC.nf
@@ -676,7 +676,7 @@ if ('preprocessing' in workflowSteps) {
 
   recalibrationTable = logChannelContent("Base recalibrated table for recalibration: ", recalibrationTable)
 } else if ('recalibrate' in workflowSteps) {
-  println file('Preprocessing').mkdir ? "Folder Preprocessing created" : "Cannot create folder Preprocessing"
+  println file('Preprocessing').mkdir() ? "Folder Preprocessing created" : "Cannot create folder Preprocessing"
   println file('Preprocessing/Recalibrated').mkdir() ? "Folder Preprocessing/Recalibrated created" : "Cannot create folder Preprocessing/Recalibrated"
 
   recalibrationTable = bamFiles

--- a/MultiFQtoVC.nf
+++ b/MultiFQtoVC.nf
@@ -355,6 +355,8 @@ if ('preprocessing' in workflowSteps) {
     module 'bwa/0.7.13'
     module 'samtools/1.3'
 
+    tag "$idRun"
+
     time { params.runTime * task.attempt }
     errorStrategy { task.exitStatus == 143 ? 'retry' : 'terminate' }
     maxRetries 3

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Nextflow Cancer Analysis Workflow Prototype developed at @SciLifeLab
 
 ## Version
-0.8.1
+0.8.2
 
 ## Authors
 - Sebastian DiLorenzo (@Sebastian-D)


### PR DESCRIPTION
So I propose to keep in `Preprocessing`, copies of non-recalibrated and recalibrated files (respectively in `NonRecalibrated` and `Recalibrated` directories).
It both directories there are of course accompanying TSV files.
And then if the pipeline worked without problems, to use `nextflow clean -f` to get rid of the temp files.
`nextflow clean -f` remove all the temp files from the lastest run, but keep some folders (I guess it'll get better in future versions). 

cf issue #46