### PR TITLE
moved Manta references and centromeres list to the Toolbox. Furthermo…

### DIFF
--- a/config/milou-github.config
+++ b/config/milou-github.config
@@ -29,14 +29,14 @@ timeline {
 }
 
 params {
-  singleCPUMem  = '32.G'         // for processes that are using more memory but a single CPU only. Use the 'core' queue for these
-  MuTect1Mem    = '16.G'        // MuTect1 hardly ever uses more memory
+  singleCPUMem  = '32.GB'         // for processes that are using more memory but a single CPU only. Use the 'core' queue for these
+  MuTect1Mem    = '16.GB'        // MuTect1 hardly ever uses more memory
   runTime       = '48.h'
   gender        = 'XY'
   genome        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta'
   genomeIndex   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.fai'
-  mantaRef      = '/proj/b2013064/jesper/human_g1k_v37_decoy.fasta'
-  mantaIndex    = '/proj/b2013064/jesper/human_g1k_v37_decoy.fasta.fai'
+  mantaRef      = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/MANTA_human_g1k_v37_decoy.fasta'
+  mantaIndex    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/MANTA_human_g1k_v37_decoy.fasta.fai'
   genomeDict    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.dict'
   cosmic41      = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/b37_cosmic_v74.noCHR.sort.4.1.vcf'
   cosmicIndex41 = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/b37_cosmic_v74.noCHR.sort.4.1.vcf.idx'
@@ -57,6 +57,6 @@ params {
   strelkaHome   = '/sw/apps/bioinfo/strelka/1.0.15/milou'
   strelkaCFG    = '/sw/apps/bioinfo/strelka/1.0.15/milou/etc/strelka_config_bwa_default.ini'
   SNIC_tmp_dir  = '${SNIC_TMP?:"/tmp"}'
-  intervals     = "$NXF_HOME/assets/SciLifeLab/CAW/repeats/centromeres.list"
+  intervals     = "/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/centromeres.list"
   acLoci        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase3_20130502_SNP_maf0.3.loci'
 }


### PR DESCRIPTION
This time Manta should work with this reference. Manta failed because we were not doing realignment and recalibration for the decoy sequence, therefore it is missing from the BAM header. So I have created a reference and its index without this sequence, and moved to Toolbox to make sure it will be present on irma/bianca later.
Also, the centromeres.list file is copied there as it is a pretty general file and handy to have it there.