### PR TITLE
Speed up mapping by not running samtools view

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -184,7 +184,6 @@ process MapReads {
   """
   set -eo pipefail
   bwa mem -R \"$readGroup\" -B 3 -t $task.cpus -M ${referenceMap['genomeFile']} $fastqFile1 $fastqFile2 | \
-  samtools view --threads $task.cpus -bS -t ${referenceMap['genomeIndex']} - | \
   samtools sort --threads $task.cpus - > ${idRun}.bam
   """
 }


### PR DESCRIPTION
Recent `samtools sort` versions support reading SAM from stdin (they still write BAM output). In my tests, leaving out this line gives a binary identical BAM file in the end, but is roughly 10% faster. The speedup comes from getting rid of one compression/decompression round (`samtools view` compresses its output, which is then immediately decompressed by `samtools sort`).