### PR TITLE
Fixed check for multiple alternative alleles

### DIFF
--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -354,8 +354,8 @@ def parse_strelka_snvs(vcf):
             if len(alt) > 1:
                 print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line
-            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(major_alt_ad)
-            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(ad_normal[alt])
+            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(major_alt_tumor)
+            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(major_alt_normal)
             #else:
             #    print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
             #    print line

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -344,11 +344,13 @@ def parse_strelka_snvs(vcf):
 
             #alt_allele_index={"A":4,"C":5,"G":6,"T":7}
 
-            major_alt_ad = 0
+            major_alt_tumor = 0
+            major_alt_normal = 0
             alt_alleles=alt.split(",")
             for allele in alt_alleles:
-                if ad_tumor[allele] > major_alt_ad:
-                    major_alt_ad=ad_tumor[allele]
+                if ad_tumor[allele] > major_alt_tumor:
+                    major_alt_tumor=ad_tumor[allele]
+                    major_alt_normal=ad_normal[allele]
             if len(alt) > 1:
                 print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -342,7 +342,8 @@ def parse_strelka_snvs(vcf):
             snvs[pos]['ad'] = {}
             alt_allele_index={"A":4,"C":5,"G":6,"T":7}
             major_alt_ad = 0
-            for a in range(alt):
+            alt_alleles=alt.split(",")
+            for a in alt_alleles:
                 if ad_tumor[alt_allele_index[a]] > major_alt_ad:
                     major_alt_ad=ad_tumor[alt_allele_index[a]]
             if len(alt) > 1:

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -269,11 +269,12 @@ def parse_mutect2(vcf):
                 info=line.split("\t")
                 pos=info[0]+'_'+info[1]
                 vcfinfo=info[0]+'\t'+info[1]+'\t'+info[3]+'\t'+info[4]
-                if info[4] in ['A', 'C', 'G', 'T']:
-                    ad_tumor=info[9].split(":")[1]
-                    ad_normal=info[10].split(":")[1]
-                    ref=info[3]
-                    alt=info[4]
+                ad_tumor=info[9].split(":")[1]
+                ad_normal=info[10].split(":")[1]
+                ref=info[3]
+                alt=info[4]
+                alt_alleles = alt.split(",")
+                if len(alt_alleles) == 1:
                     #Indels
                     if len(ref)>1 or len(alt)>1:
                         indels[pos] = {}
@@ -289,7 +290,7 @@ def parse_mutect2(vcf):
                         snvs[pos]['ad']['tumor']=ad_tumor
                         snvs[pos]['ad']['normal']=ad_normal
                 else:
-                    print "WARNING: MuTect2 variant with multiple alternative alleles detected. Skipped and not used in merged callset."
+                    print "WARNING: MuTect2 variant with multiple alternative alleles detected; skipped and not used in merged callset:"
                     print line
     return {'indels':indels,'snvs':snvs}
 
@@ -303,18 +304,20 @@ def parse_mutect1(vcf):
             f1=filter1.search(line)
             if not (f1):
                 info=line.split("\t")
-                pos=info[0]+'_'+info[1]
-                vcfinfo=info[0]+'\t'+info[1]+'\t'+info[3]+'\t'+info[4]
-                if info[4] in ['A', 'C', 'G', 'T']:
-                    ad_tumor=info[9].split(":")[1]
-                    ad_normal=info[10].split(":")[1]
+                pos = info[0] + '_' + info[1]
+                vcfinfo = info[0] + '\t' + info[1] + '\t' + info[3] + '\t' + info[4]
+                ad_tumor = info[9].split(":")[1]
+                ad_normal = info[10].split(":")[1]
+                alt=info[4]
+                alt_alleles=alt.split(",")
+                if len(alt_alleles) == 1:
                     snvs[pos] = {}
                     snvs[pos]['info']=vcfinfo
                     snvs[pos]['ad'] = {}
                     snvs[pos]['ad']['tumor']=ad_tumor
                     snvs[pos]['ad']['normal']=ad_normal
                 else:
-                    print "WARNING: MuTect1 variant with multiple alternative alleles detected. Skipped and not used in merged callset."
+                    print "WARNING: MuTect1 variant with multiple alternative alleles detected; skipped and not used in merged callset."
                     print line
     return {'snvs':snvs}
 

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -325,29 +325,29 @@ def parse_strelka_snvs(vcf):
             ref=info[3]
             alt=info[4]
             #Check if SNP has one alternative allele:
-            if alt in ['A','C','G','T']:
-                ad_normal = {}
-                ad_tumor = {}
-                #Using tiers 2 data
-                ad_tumor['A']=int(info[10].split(":")[4].split(",")[1])
-                ad_tumor['C']=int(info[10].split(":")[5].split(",")[1])
-                ad_tumor['G']=int(info[10].split(":")[6].split(",")[1])
-                ad_tumor['T']=int(info[10].split(":")[7].split(",")[1])
-                ad_normal['A']=int(info[9].split(":")[4].split(",")[1])
-                ad_normal['C']=int(info[9].split(":")[5].split(",")[1])
-                ad_normal['G']=int(info[9].split(":")[6].split(",")[1])
-                ad_normal['T']=int(info[9].split(":")[7].split(",")[1])
-                snvs[pos] = {}
-                snvs[pos]['info']=vcfinfo
-                snvs[pos]['ad'] = {}
-                if len(alt) > 1:
-                    print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
-                    print line
-                snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(ad_tumor[alt])
-                snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(ad_normal[alt])
-            else:
+            #if alt in ['A','C','G','T']:
+            ad_normal = {}
+            ad_tumor = {}
+            #Using tiers 2 data
+            ad_tumor['A']=int(info[10].split(":")[4].split(",")[1])
+            ad_tumor['C']=int(info[10].split(":")[5].split(",")[1])
+            ad_tumor['G']=int(info[10].split(":")[6].split(",")[1])
+            ad_tumor['T']=int(info[10].split(":")[7].split(",")[1])
+            ad_normal['A']=int(info[9].split(":")[4].split(",")[1])
+            ad_normal['C']=int(info[9].split(":")[5].split(",")[1])
+            ad_normal['G']=int(info[9].split(":")[6].split(",")[1])
+            ad_normal['T']=int(info[9].split(":")[7].split(",")[1])
+            snvs[pos] = {}
+            snvs[pos]['info']=vcfinfo
+            snvs[pos]['ad'] = {}
+            if len(alt) > 1:
                 print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
                 print line
+            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(ad_tumor[alt])
+            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(ad_normal[alt])
+            #else:
+            #    print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
+            #    print line
 
     return {'snvs':snvs}
 

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -354,6 +354,8 @@ def parse_strelka_snvs(vcf):
             if len(alt) > 1:
                 print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line
+                print major_alt_normal
+                print major_alt_tumor
             snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(major_alt_tumor)
             snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(major_alt_normal)
             #else:

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -353,9 +353,9 @@ def parse_strelka_snvs(vcf):
             alt_alt_normal = 0
             alt_alleles=alt.split(",")
             for allele in alt_alleles:
-                if ad_tumor[allele] > major_alt_tumor:
-                    major_alt_tumor=ad_tumor[allele]
-                    major_alt_normal=ad_normal[allele]
+                if ad_tumor[allele] > alt_depth_tumor:
+                    alt_depth_tumor=ad_tumor[allele]
+                    alt_depth_normal=ad_normal[allele]
                     alt_allele=allele
 
             if len(alt) > 1:
@@ -366,8 +366,8 @@ def parse_strelka_snvs(vcf):
 
             vcfinfo = info[0] + '\t' + info[1] + '\t' + info[3] + '\t' + alt_allele
             snvs[pos]['info'] = vcfinfo
-            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(major_alt_tumor)
-            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(major_alt_normal)
+            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(alt_depth_tumor)
+            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(alt_depth_normalormal)
 
             print snvs[pos]['ad']['tumor']
             print snvs[pos]['ad']['normal']

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -361,8 +361,8 @@ def parse_strelka_snvs(vcf):
             if len(alt) > 1:
                 print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line
-                print major_alt_normal
-                print major_alt_tumor
+                print alt_depth_tumor
+                print alt_depth_normal
 
             vcfinfo = info[0] + '\t' + info[1] + '\t' + info[3] + '\t' + alt_allele
             snvs[pos]['info'] = vcfinfo

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -340,10 +340,11 @@ def parse_strelka_snvs(vcf):
             snvs[pos] = {}
             snvs[pos]['info']=vcfinfo
             snvs[pos]['ad'] = {}
+            alt_allele_index={"A":4,"C":5,"G":6,"T":7}
             major_alt_ad = 0
-            for a in range(0,(len(alt)-1)):
-                if int(info[9].split(":")[a].split(",")[1]) > major_alt_ad:
-                    major_alt_ad=int(info[9].split(":")[a].split(",")[1])
+            for a in range(alt):
+                if ad_tumor[alt_allele_index[a]] > major_alt_ad:
+                    major_alt_ad=ad_tumor[alt_allele_index[a]]
             if len(alt) > 1:
                 print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -321,7 +321,10 @@ def parse_strelka_snvs(vcf):
         if not line.startswith("#"):
             info=line.split("\t")
             pos=info[0]+'_'+info[1]
-            vcfinfo=info[0]+'\t'+info[1]+'\t'+info[3]+'\t'+info[4]
+
+
+
+
             ref=info[3]
             alt=info[4]
             #Check if SNP has one alternative allele:
@@ -337,25 +340,32 @@ def parse_strelka_snvs(vcf):
             ad_normal['C']=int(info[9].split(":")[5].split(",")[1])
             ad_normal['G']=int(info[9].split(":")[6].split(",")[1])
             ad_normal['T']=int(info[9].split(":")[7].split(",")[1])
+
+
+
             snvs[pos] = {}
-            snvs[pos]['info']=vcfinfo
+
             snvs[pos]['ad'] = {}
 
-
-            #alt_allele_index={"A":4,"C":5,"G":6,"T":7}
-
-            major_alt_tumor = 0
-            major_alt_normal = 0
+            #Fetch the most highly abundant alternative allele in the tumor and report that one.
+            alt_allele=''
+            alt_depth_tumor = 0
+            alt_alt_normal = 0
             alt_alleles=alt.split(",")
             for allele in alt_alleles:
                 if ad_tumor[allele] > major_alt_tumor:
                     major_alt_tumor=ad_tumor[allele]
                     major_alt_normal=ad_normal[allele]
+                    alt_allele=allele
+
             if len(alt) > 1:
                 print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line
                 print major_alt_normal
                 print major_alt_tumor
+
+            vcfinfo = info[0] + '\t' + info[1] + '\t' + info[3] + '\t' + alt_allele
+            snvs[pos]['info'] = vcfinfo
             snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(major_alt_tumor)
             snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(major_alt_normal)
 

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -1,14 +1,15 @@
 #! /usr/bin/env python
 
-import sys, re, math, random
+import re
+import sys
+
 import matplotlib
+
 matplotlib.use('pdf')
 import matplotlib.pyplot as plt
 import numpy as np
-import numpy.ma as ma
 from matplotlib.backends.backend_pdf import PdfPages
 from datetime import datetime
-import operator
 
 if len(sys.argv)<5:
     print "Usage: %s sample_name MuTect1_vcf MuTect2_vcf Strelka_vcf genomeIndex\n" %sys.argv[0]
@@ -319,22 +320,28 @@ def parse_strelka_snvs(vcf):
             vcfinfo=info[0]+'\t'+info[1]+'\t'+info[3]+'\t'+info[4]
             ref=info[3]
             alt=info[4]
-            ad_normal = {}
-            ad_tumor = {}
-            #Using tiers 2 data
-            ad_tumor['A']=int(info[10].split(":")[4].split(",")[1])
-            ad_tumor['C']=int(info[10].split(":")[5].split(",")[1])
-            ad_tumor['G']=int(info[10].split(":")[6].split(",")[1])
-            ad_tumor['T']=int(info[10].split(":")[7].split(",")[1])
-            ad_normal['A']=int(info[9].split(":")[4].split(",")[1])
-            ad_normal['C']=int(info[9].split(":")[5].split(",")[1])
-            ad_normal['G']=int(info[9].split(":")[6].split(",")[1])
-            ad_normal['T']=int(info[9].split(":")[7].split(",")[1])
-            snvs[pos] = {}
-            snvs[pos]['info']=vcfinfo
-            snvs[pos]['ad'] = {}
-            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(ad_tumor[alt])
-            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(ad_normal[alt])
+            #Check if SNP has one alternative allele:
+            if alt in ['A','C','G','T']:
+                ad_normal = {}
+                ad_tumor = {}
+                #Using tiers 2 data
+                ad_tumor['A']=int(info[10].split(":")[4].split(",")[1])
+                ad_tumor['C']=int(info[10].split(":")[5].split(",")[1])
+                ad_tumor['G']=int(info[10].split(":")[6].split(",")[1])
+                ad_tumor['T']=int(info[10].split(":")[7].split(",")[1])
+                ad_normal['A']=int(info[9].split(":")[4].split(",")[1])
+                ad_normal['C']=int(info[9].split(":")[5].split(",")[1])
+                ad_normal['G']=int(info[9].split(":")[6].split(",")[1])
+                ad_normal['T']=int(info[9].split(":")[7].split(",")[1])
+                snvs[pos] = {}
+                snvs[pos]['info']=vcfinfo
+                snvs[pos]['ad'] = {}
+                snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(ad_tumor[alt])
+                snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(ad_normal[alt])
+            else:
+                print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
+                print line
+
     return {'snvs':snvs}
 
 main()

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -358,6 +358,9 @@ def parse_strelka_snvs(vcf):
                 print major_alt_tumor
             snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(major_alt_tumor)
             snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(major_alt_normal)
+
+            print snvs[pos]['ad']['tumor']
+            print snvs[pos]['ad']['normal']
             #else:
             #    print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
             #    print line

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -340,12 +340,15 @@ def parse_strelka_snvs(vcf):
             snvs[pos] = {}
             snvs[pos]['info']=vcfinfo
             snvs[pos]['ad'] = {}
-            alt_allele_index={"A":4,"C":5,"G":6,"T":7}
+
+
+            #alt_allele_index={"A":4,"C":5,"G":6,"T":7}
+
             major_alt_ad = 0
             alt_alleles=alt.split(",")
-            for a in alt_alleles:
-                if ad_tumor[alt_allele_index[a]] > major_alt_ad:
-                    major_alt_ad=ad_tumor[alt_allele_index[a]]
+            for allele in alt_alleles:
+                if ad_tumor[allele] > major_alt_ad:
+                    major_alt_ad=ad_tumor[allele]
             if len(alt) > 1:
                 print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -301,13 +301,17 @@ def parse_mutect1(vcf):
                 info=line.split("\t")
                 pos=info[0]+'_'+info[1]
                 vcfinfo=info[0]+'\t'+info[1]+'\t'+info[3]+'\t'+info[4]
-                ad_tumor=info[9].split(":")[1]
-                ad_normal=info[10].split(":")[1]
-                snvs[pos] = {}
-                snvs[pos]['info']=vcfinfo
-                snvs[pos]['ad'] = {}
-                snvs[pos]['ad']['tumor']=ad_tumor
-                snvs[pos]['ad']['normal']=ad_normal
+                if info[4] in ['A', 'C', 'G', 'T']:
+                    ad_tumor=info[9].split(":")[1]
+                    ad_normal=info[10].split(":")[1]
+                    snvs[pos] = {}
+                    snvs[pos]['info']=vcfinfo
+                    snvs[pos]['ad'] = {}
+                    snvs[pos]['ad']['tumor']=ad_tumor
+                    snvs[pos]['ad']['normal']=ad_normal
+                else:
+                    print "WARNING: MuTect1 variant skipped because it has multiple alternative alleles:"
+                    print line
     return {'snvs':snvs}
 
 def parse_strelka_snvs(vcf):
@@ -336,6 +340,9 @@ def parse_strelka_snvs(vcf):
                 snvs[pos] = {}
                 snvs[pos]['info']=vcfinfo
                 snvs[pos]['ad'] = {}
+                if len(alt) > 1:
+                    print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
+                    print line
                 snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(ad_tumor[alt])
                 snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(ad_normal[alt])
             else:

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -340,10 +340,14 @@ def parse_strelka_snvs(vcf):
             snvs[pos] = {}
             snvs[pos]['info']=vcfinfo
             snvs[pos]['ad'] = {}
+            major_alt_ad = 0
+            for a in range(0,(len(alt)-1)):
+                if int(info[9].split(":")[a].split(",")[1]) > major_alt_ad:
+                    major_alt_ad=int(info[9].split(":")[a].split(",")[1])
             if len(alt) > 1:
-                print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"
+                print "WARNING: Strelka variant with multiple alternative alleles detected. Using the alternative allele with highest read count:"
                 print line
-            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(ad_tumor[alt])
+            snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(major_alt_ad)
             snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(ad_normal[alt])
             #else:
             #    print "WARNING: Strelka variant skipped because it has multiple alternative alleles:"

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -367,7 +367,7 @@ def parse_strelka_snvs(vcf):
             vcfinfo = info[0] + '\t' + info[1] + '\t' + info[3] + '\t' + alt_allele
             snvs[pos]['info'] = vcfinfo
             snvs[pos]['ad']['tumor']=str(ad_tumor[ref])+','+str(alt_depth_tumor)
-            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(alt_depth_normalormal)
+            snvs[pos]['ad']['normal']=str(ad_normal[ref])+','+str(alt_depth_normal)
 
             print snvs[pos]['ad']['tumor']
             print snvs[pos]['ad']['normal']


### PR DESCRIPTION
For multiple alternative alleles in strelka vcf: The one with highest read depth in the tumor is used. 

SNVs with multiple alternative alleles reported by MuTect1 or MuTect2 are skipped.

If any of the above is detected a warning message is printed to the screen. 

So far a few cases of "two alternative alleles" in Strelka vcf has been detected (in 12 samples)
No examples of multiple alternative alleles in MuTect1 or MuTect2 vcfs have been detected (not sure f there are any). 

fix #194 