### PR TITLE
Fix in merge_callers.py

### DIFF
--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -243,6 +243,7 @@ def sort_positions(positions, genomeIndex):
 def parse_mutect2(vcf):
     snvs = {}
     indels = {}
+    datacolumn = {}
     for line in open(vcf, 'r'):
         line=line.strip()
         # Extract column in vcf file for "TUMOR" and "NORMAL"
@@ -305,7 +306,6 @@ def parse_mutect2(vcf):
 
 def parse_mutect1(vcf, tumorid, normalid):
     snvs = {}
-
     datacolumn = {}
     for line in open(vcf, 'r'):
         line=line.strip()
@@ -342,6 +342,7 @@ def parse_mutect1(vcf, tumorid, normalid):
 
 def parse_strelka_snvs(vcf):
     snvs = {}
+    datacolumn = {}
     for line in open(vcf, 'r'):
         line=line.strip()
         # Extract column in vcf file for "TUMOR" and "NORMAL"

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -316,8 +316,8 @@ def parse_mutect1(vcf, tumorid, normalid):
                 info=line.split("\t")
                 pos = info[0] + '_' + info[1]
                 vcfinfo = info[0] + '\t' + info[1] + '\t' + info[3] + '\t' + info[4]
-                ad_tumor = datacolumn[tumorid].split(":")[1]
-                ad_normal = datacolum[normalid].split(":")[1]
+                ad_tumor = info[datacolumn[tumorid]].split(":")[1]
+                ad_normal = info[datacolum[normalid]].split(":")[1]
                 alt=info[4]
                 alt_alleles=alt.split(",")
                 if len(alt_alleles) == 1:

--- a/scripts/merge_callers.py
+++ b/scripts/merge_callers.py
@@ -317,7 +317,7 @@ def parse_mutect1(vcf, tumorid, normalid):
                 pos = info[0] + '_' + info[1]
                 vcfinfo = info[0] + '\t' + info[1] + '\t' + info[3] + '\t' + info[4]
                 ad_tumor = info[datacolumn[tumorid]].split(":")[1]
-                ad_normal = info[datacolum[normalid]].split(":")[1]
+                ad_normal = info[datacolumn[normalid]].split(":")[1]
                 alt=info[4]
                 alt_alleles=alt.split(",")
                 if len(alt_alleles) == 1:


### PR DESCRIPTION
Now extracts genotyping columns for tumor and normal based on the order between the samples in the definition row (the one starting with #chrom ....). 
Earlier version of the script assumed that tumor data was in column 9 and normal data was in column 10, but this was not OK for MuTect1. 
Fixed column numbers are probably OK for MuTect2 and Strelka because these programs have "NORMAL" and "TUMOR" as header and the order seem to be the same in all tested files. 
MuTect1 uses the tumorid and normalid as headers and the order between them is different between samples, so they really need to be parsed. 
Now I'm parsing the genotype columns for tumor and normal in all VCF files, either by looking for the tumorid and normalid (MuTect1) or for "NORMAL" and "TUMOR" (Strelka and MuTect2). 
fix #197 