### PR TITLE
Refactoring for version 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](doc/images/CAW-logo.png "CAW")][CAW-site-link]
+[![](doc/images/CAW-logo.png "CAW")][caw-site-link]
 
 # Cancer Analysis Workflow
 
@@ -46,11 +46,12 @@ For further information/help contact: maxime.garcia@scilifelab.se, szilveszter.j
 - [Pall Olason](https://github.com/pallolason)
 - [Pelin Sahlén](https://github.com/pelinakan)
 
----
+--------------------------------------------------------------------------------
+
 [![](doc/images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](doc/images/NGI-final-small.png "NGI")][ngi-link]
 
 [ascat-link]: https://github.com/Crick-CancerGenomics/ascat
-[CAW-site-link]: http://opensource.scilifelab.se/projects/caw/
+[caw-site-link]: http://opensource.scilifelab.se/projects/caw/
 [gatk-link]: https://github.com/broadgsa/gatk-protected
 [gitter-badge]: https://badges.gitter.im/SciLifeLab/CAW.svg
 [gitter-link]: https://gitter.im/SciLifeLab/CAW

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![](doc/images/CAW-logo.png "CAW")](https://github.com/SciLifeLab/CAW)
+[![](doc/images/CAW-logo.png "CAW")][CAW-site-link]
 
 # Cancer Analysis Workflow
 
@@ -50,6 +50,7 @@ For further information/help contact: maxime.garcia@scilifelab.se, szilveszter.j
 [![](doc/images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](doc/images/NGI-final-small.png "NGI")][ngi-link]
 
 [ascat-link]: https://github.com/Crick-CancerGenomics/ascat
+[CAW-site-link]: http://opensource.scilifelab.se/projects/caw/
 [gatk-link]: https://github.com/broadgsa/gatk-protected
 [gitter-badge]: https://badges.gitter.im/SciLifeLab/CAW.svg
 [gitter-link]: https://gitter.im/SciLifeLab/CAW

--- a/configuration/docker-skadi.config
+++ b/configuration/docker-skadi.config
@@ -70,7 +70,7 @@ process {
     time = {params.runTime * task.attempt}
   }
   $RunSamtoolsStats {
-    container = 'maxulysse/samtools:1.3'
+    container = 'maxulysse/samtools:dev'
     time = {params.runTime * task.attempt}
   }
   $RunHaplotypecaller {

--- a/configuration/docker-skadi.config
+++ b/configuration/docker-skadi.config
@@ -104,7 +104,7 @@ process {
   //   memory = {params.singleCPUMem * 4 * task.attempt}
   // }
   $ConcatVCF {
-    container = 'maxulysse/gatk:dev'
+    container = 'maxulysse/concatvcf:dev'
   }
   $RunStrelka {
     container = 'maxulysse/strelka:dev'
@@ -158,8 +158,6 @@ params {
   intervals     = "/home/max/ReferenceAssemblies/hg38make/b37/centromeres.list"
   kgIndels      = '/home/max/ReferenceAssemblies/hg38make/b37/1000G_phase1.indels.b37.vcf'
   kgIndex       = '/home/max/ReferenceAssemblies/hg38make/b37/1000G_phase1.indels.b37.vcf.idx'
-  mantaIndex    = '/home/max/ReferenceAssemblies/hg38make/b37/MANTA_human_g1k_v37_decoy.fasta.fai'
-  mantaRef      = '/home/max/ReferenceAssemblies/hg38make/b37/MANTA_human_g1k_v37_decoy.fasta'
   millsIndels   = '/home/max/ReferenceAssemblies/hg38make/b37/Mills_and_1000G_gold_standard.indels.b37.vcf'
   millsIndex    = '/home/max/ReferenceAssemblies/hg38make/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx'
   snpeffDb      = 'GRCh37.75'

--- a/configuration/docker-skadi.config
+++ b/configuration/docker-skadi.config
@@ -10,6 +10,13 @@ vim: syntax=groovy
  * as $NXF_HOME/config
  */
 
+env {
+  NXF_OPTS="-Xms1g -Xmx4g"
+}
+
+docker {
+  enabled = true
+}
 
 executor {
   name = 'local'
@@ -21,6 +28,114 @@ process {
   cpus = 8
   memory = 15.GB
   time = 1.h
+
+  errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
+  maxRetries = 3
+  maxErrors = '-1'
+
+  $RunFastQC {
+    container = 'maxulysse/fastqc:dev'
+    errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
+  }
+  $MapReads {
+    container = 'maxulysse/mapreads:dev'
+    time = {params.runTime * task.attempt}
+  }
+  $MergeBams {
+    container = 'maxulysse/samtools:dev'
+    time = {params.runTime * task.attempt}
+    cpus = 1
+    memory = {params.singleCPUMem * task.attempt}
+  }
+  $MarkDuplicates {
+    container = 'maxulysse/picard:dev'
+    time = {params.runTime * task.attempt}
+    cpus = 1
+    memory = {params.singleCPUMem * 8 * task.attempt}
+  }
+  $CreateIntervals {
+    container = 'maxulysse/gatk:dev'
+    time = {params.runTime * task.attempt}
+  }
+  $RealignBams {
+    container = 'maxulysse/gatk:dev'
+    time = {params.runTime * task.attempt}
+  }
+  $CreateRecalibrationTable {
+    container = 'maxulysse/gatk:dev'
+    time = {params.runTime * task.attempt}
+  }
+  $RecalibrateBam {
+    container = 'maxulysse/gatk:dev'
+    time = {params.runTime * task.attempt}
+  }
+  $RunSamtoolsStats {
+    container = 'maxulysse/samtools:1.3'
+    time = {params.runTime * task.attempt}
+  }
+  $RunHaplotypecaller {
+    container = 'maxulysse/gatk:dev'
+    time = {params.runTime * task.attempt}
+    cpus = 1
+    memory = {params.singleCPUMem * 8 *task.attempt}
+  }
+  $RunMutect1 {
+    container = 'maxulysse/mutect1:dev'
+    time = {params.runTime * task.attempt}
+    cpus = 1
+    memory = {params.singleCPUMem * 2 * task.attempt}
+  }
+  $RunMutect2 {
+    container = 'maxulysse/gatk:dev'
+    time = {params.runTime * task.attempt}
+    cpus = 1
+    memory = {params.singleCPUMem * 2 * task.attempt}
+  }
+  // $RunFreeBayes {
+  //   module = ['bioinfo-tools', 'java/sun_jdk1.8.0_40', 'freebayes/1.0.2']
+  //   time = {params.runTime * task.attempt}
+  //   cpus = 1
+  //   memory = {params.singleCPUMem * 4 * task.attempt}
+  // }
+  // $RunVardict {
+  //   module = ['bioinfo-tools', 'java/sun_jdk1.8.0_40', 'R/3.2.3', 'gcc/4.9.2', 'perl/5.18.4']
+  //   time = {params.runTime * task.attempt}
+  //   cpus = 1
+  //   memory = {params.singleCPUMem * 4 * task.attempt}
+  // }
+  $ConcatVCF {
+    container = 'maxulysse/gatk:dev'
+  }
+  $RunStrelka {
+    container = 'maxulysse/strelka:dev'
+    time = {params.runTime * task.attempt}
+  }
+  $RunManta {
+    container = 'maxulysse/runmanta:dev'
+  }
+  $RunAlleleCount {
+    container = 'maxulysse/runallelecount:dev'
+    cpus = 1
+    memory = {params.singleCPUMem * 2 * task.attempt}
+  }
+  $RunConvertAlleleCounts {
+    container = 'maxulysse/runconvertallelecounts:dev'
+    cpus = 1
+    memory = {params.singleCPUMem * 2 * task.attempt}
+  }
+  $RunAscat {
+  container = 'maxulysse/runascat:dev'
+    cpus = 1
+    memory = {params.singleCPUMem * 2 * task.attempt}
+  }
+  $RunSnpeff {
+    container = 'maxulysse/snpeff:dev'
+    errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
+  }
+  $RunMultiQC {
+    container = 'maxulysse/multiqc:dev'
+    errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
+  }
 }
 
 params {

--- a/configuration/docker-test.config
+++ b/configuration/docker-test.config
@@ -41,8 +41,6 @@ params {
   intervals     = "/PathToReferences/centromeres.list"
   kgIndels      = '/PathToReferences/1000G_phase1.indels.b37.vcf'
   kgIndex       = '/PathToReferences/1000G_phase1.indels.b37.vcf.idx'
-  mantaIndex    = '/PathToReferences/human_g1k_v37_decoy.fasta'
-  mantaRef      = '/PathToReferences/human_g1k_v37_decoy.fasta.fai'
   millsIndels   = '/PathToReferences/Mills_and_1000G_gold_standard.indels.b37.vcf'
   millsIndex    = '/PathToReferences/Mills_and_1000G_gold_standard.indels.b37.vcf.idx'
   snpeffDb      = 'GRCh37.75'

--- a/configuration/docker.config
+++ b/configuration/docker.config
@@ -94,7 +94,7 @@ process {
   //   memory = {params.singleCPUMem * 4 * task.attempt}
   // }
   $ConcatVCF {
-    container = 'maxulysse/gatk:1.0'
+    container = 'maxulysse/concatvcf:1.0'
   }
   $RunStrelka {
     container = 'maxulysse/strelka:1.0'

--- a/configuration/docker.config
+++ b/configuration/docker.config
@@ -24,59 +24,59 @@ process {
   maxErrors = '-1'
 
   $RunFastQC {
-    container = 'maxulysse/fastqc:1.0'
+    container = 'maxulysse/fastqc:1.1'
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $MapReads {
-    container = 'maxulysse/mapreads:1.0'
+    container = 'maxulysse/mapreads:1.1'
     time = {params.runTime * task.attempt}
   }
   $MergeBams {
-    container = 'maxulysse/samtools:1.0'
+    container = 'maxulysse/samtools:1.1'
     time = {params.runTime * task.attempt}
     cpus = 1
     memory = {params.singleCPUMem * task.attempt}
   }
   $MarkDuplicates {
-    container = 'maxulysse/picard:1.0'
+    container = 'maxulysse/picard:1.1'
     time = {params.runTime * task.attempt}
     cpus = 1
     memory = {params.singleCPUMem * 8 * task.attempt}
   }
   $CreateIntervals {
-    container = 'maxulysse/gatk:1.0'
+    container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
   }
   $RealignBams {
-    container = 'maxulysse/gatk:1.0'
+    container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
   }
   $CreateRecalibrationTable {
-    container = 'maxulysse/gatk:1.0'
+    container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
   }
   $RecalibrateBam {
-    container = 'maxulysse/gatk:1.0'
+    container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
   }
   $RunSamtoolsStats {
-    container = 'maxulysse/samtools:1.3'
+    container = 'maxulysse/samtools:1.1'
     time = {params.runTime * task.attempt}
   }
   $RunHaplotypecaller {
-    container = 'maxulysse/gatk:1.0'
+    container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
     cpus = 1
     memory = {params.singleCPUMem * 8 *task.attempt}
   }
   $RunMutect1 {
-    container = 'maxulysse/mutect1:1.0'
+    container = 'maxulysse/mutect1:1.1'
     time = {params.runTime * task.attempt}
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunMutect2 {
-    container = 'maxulysse/gatk:1.0'
+    container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
@@ -94,37 +94,37 @@ process {
   //   memory = {params.singleCPUMem * 4 * task.attempt}
   // }
   $ConcatVCF {
-    container = 'maxulysse/concatvcf:1.0'
+    container = 'maxulysse/concatvcf:1.1'
   }
   $RunStrelka {
-    container = 'maxulysse/strelka:1.0'
+    container = 'maxulysse/strelka:1.1'
     time = {params.runTime * task.attempt}
   }
   $RunManta {
-    container = 'maxulysse/runmanta:1.0'
+    container = 'maxulysse/runmanta:1.1'
   }
   $RunAlleleCount {
-    container = 'maxulysse/runallelecount:1.0'
+    container = 'maxulysse/runallelecount:1.1'
     module = ['bioinfo-tools', 'alleleCount']
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunConvertAlleleCounts {
-    container = 'maxulysse/runconvertallelecounts:1.0'
+    container = 'maxulysse/runconvertallelecounts:1.1'
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunAscat {
-  container = 'maxulysse/runascat:1.0'
+  container = 'maxulysse/runascat:1.1'
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunSnpeff {
-    container = 'maxulysse/snpeff:1.0'
+    container = 'maxulysse/snpeff:1.1'
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunMultiQC {
-    container = 'maxulysse/multiqc:1.0'
+    container = 'maxulysse/multiqc:1.1'
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }

--- a/configuration/docker.config
+++ b/configuration/docker.config
@@ -94,7 +94,7 @@ process {
   //   memory = {params.singleCPUMem * 4 * task.attempt}
   // }
   $ConcatVCF {
-    container = 'maxulysse/concatvcf:1.0'
+    container = 'maxulysse/gatk:1.0'
   }
   $RunStrelka {
     container = 'maxulysse/strelka:1.0'

--- a/configuration/docker.config
+++ b/configuration/docker.config
@@ -109,15 +109,16 @@ process {
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
-  // $RunConvertAlleleCounts {
-  //   cpus = 1
-  //   memory = {params.singleCPUMem * 2 * task.attempt}
-  // }
-  // $RunAscat {
-  //   module = ['R/3.2.3']
-  //   cpus = 1
-  //   memory = {params.singleCPUMem * 2 * task.attempt}
-  // }
+  $RunConvertAlleleCounts {
+    container = 'maxulysse/runconvertallelecounts:1.0'
+    cpus = 1
+    memory = {params.singleCPUMem * 2 * task.attempt}
+  }
+  $RunAscat {
+  container = 'maxulysse/runascat:1.0'
+    cpus = 1
+    memory = {params.singleCPUMem * 2 * task.attempt}
+  }
   $RunSnpeff {
     container = 'maxulysse/snpeff:1.0'
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }

--- a/doc/ASCAT.md
+++ b/doc/ASCAT.md
@@ -35,7 +35,7 @@ Caclculation of LogR and BAF based on AlleleCount output is done as in [runASCAT
 
 ### Loci file
 
-The loci file was created based on the 1000Genomes latest release (phase 3, releasedate 20130502), available [here](ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp//release/20130502/ALL.wgs.phase3_shapeit2_mvncall_integrated_v5b.20130502.sites.vcf.gz). The following filter was applied: Only bi-allelc SNPs with minor allele frequencies > 0.3. The filtered file can be found on [export.uppmax.uu.se](https://export.uppmax.uu.se/b2015110/caw-references/b37/1000G_phase3_20130502_SNP_maf0.3.loci.tar.bz2) and is stored on Milou in:
+The loci file was created based on the 1000Genomes latest release (phase 3, releasedate 20130502), available [here](ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp//release/20130502/ALL.wgs.phase3_shapeit2_mvncall_integrated_v5b.20130502.sites.vcf.gz). The following filter was applied: Only bi-allelc SNPs with minor allele frequencies > 0.3\. The filtered file can be found on [export.uppmax.uu.se](https://export.uppmax.uu.se/b2015110/caw-references/b37/1000G_phase3_20130502_SNP_maf0.3.loci.tar.bz2) and is stored on Milou in:
 
 ```
 /sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase3_20130502_SNP_maf0.3.loci
@@ -74,7 +74,8 @@ sbatch -A PROJID -p core -n 1 -t 240:00:00 -J ascat -e ascat.err -o ascat.out ru
 
 ![Overview of ASCAT process](images/ascat.jpg "ASCAT")
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/doc/FOLDER.md
+++ b/doc/FOLDER.md
@@ -48,7 +48,8 @@ Read group information will be parsed from fastq file names according to this:
 - `PU` = sample
 - `RGLB` = lib
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -62,7 +62,8 @@ $ nextflow run main.nf -profile interactive --test --project <UPPMAX Project ID>
 
 For more tests, see [Usage documentation](USAGE.md#test)
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/doc/PROCESS.md
+++ b/doc/PROCESS.md
@@ -35,7 +35,7 @@ Several processes are run within the workflow. We divide them for the moment int
 
   ## Annotation:
 
-  - snpEff - Run snpEff on vcf files [Working]
+  - RunSnpeff - Run snpEff on vcf files [Working]
 
 ---
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]

--- a/doc/PROCESS.md
+++ b/doc/PROCESS.md
@@ -31,13 +31,15 @@ Several processes are run within the workflow. We divide them for the moment int
 - RunFastQC - Run FastQC for QC on fastq files [Stable]
 - MarkDuplicates - Mark Duplicates [Stable]
 - RunSamtoolsStats - Run Samtools stats on recalibrated BAM files [Stable]
+- GenerateMultiQCconfig - Generate a config file for MultiQC [Stable]
 - RunMultiQC - Run MultiQC for report and QC [Stable]
 
-  ## Annotation:
+## Annotation:
 
-  - RunSnpeff - Run snpEff on vcf files [Working]
+- RunSnpeff - Run snpEff on vcf files [Working]
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/doc/REFERENCES.md
+++ b/doc/REFERENCES.md
@@ -44,8 +44,8 @@ The rest of the references files are stored in in [export.uppmax.uu.se](https://
 - 'b37_cosmic_v74.noCHR.sort.4.1.vcf.idx'
 - 'b37_cosmic_v74.noCHR.sort.4.1.vcf'
 
+--------------------------------------------------------------------------------
 
----
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/doc/TOOLS.md
+++ b/doc/TOOLS.md
@@ -18,7 +18,8 @@
 - **[snpEff][snpeff-link]** 4.2
 - **[Strelka][strelka-link]** 1.0.15
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [allelecount-link]: https://github.com/cancerit/alleleCount

--- a/doc/TSV.md
+++ b/doc/TSV.md
@@ -36,7 +36,7 @@ G15511    XX    1    D0ENMT    pathToFiles/G15511.D0ENMT.md.real.bam pathToFiles
 All the files will be created in the Preprocessing/NonRealigned/ directory, and by default a corresponding TSV file will also be deposited there. Generally, getting MuTect1 and Strelka calls on the preprocessed files should be done by:
 
 ```bash
-nextflow run SciLifeLab/CAW --sample Preprocessing/NonRealigned/mysample.tsv --steps realign,MuTect1,Strelka
+nextflow run SciLifeLab/CAW --sample Preprocessing/NonRealigned/mysample.tsv --step realign --tools MuTect1,Strelka
 ```
 
 # Example TSV file for a normal/tumor pair with recalibrated BAM files
@@ -51,10 +51,11 @@ G15511    XX    1    D0ENMT    pathToFiles/G15511.D0ENMT.md.real.bam    pathToFi
 All the files will be in he Preprocessing/Recalibrated/ directory, and by default a corresponding TSV file will also be deposited there. Generally, getting MuTect1 and Strelka calls on the recalibrated files should be done by:
 
 ```bash
-nextflow run SciLifeLab/CAW --sample Preprocessing/Recalibrated/mysample.tsv --steps skipPreprocessing,MuTect1,Strelka
+nextflow run SciLifeLab/CAW --sample Preprocessing/Recalibrated/mysample.tsv --step skipPreprocessing --tool MuTect1,Strelka
 ```
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -1,6 +1,6 @@
 # Usage
 
-I would recommand to run Nextflow within a screen or tmux session (cf [help on screen](https://www.howtoforge.com/linux_screen)). It is recommanded to run only one instance of CAW for one patient in the same directory. Meaning there should be only one patient analysed in one directory. The typical command line is:
+I would recommand to run Nextflow within a [screen](https://www.gnu.org/software/screen/) or [tmux](https://tmux.github.io/) session. It is recommanded to run only one instance of CAW for one patient in the same directory. Meaning there should be only one patient analysed in one directory. The typical command line is:
 
 ```bash
 nextflow run SciLifeLab/CAW --sample <file.tsv>

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -1,56 +1,110 @@
 # Usage
 
-I would recommand to run Nextflow within a [screen](https://www.gnu.org/software/screen/) or [tmux](https://tmux.github.io/) session. It is recommanded to run only one instance of CAW for one patient in the same directory. Meaning there should be only one patient analysed in one directory. The typical command line is:
+I would recommand to run Nextflow within a [screen](https://www.gnu.org/software/screen/) or [tmux](https://tmux.github.io/) session. It is recommanded to run only one instance of CAW for one patient in the same directory. The typical reduced command line is:
 
 ```bash
-nextflow run SciLifeLab/CAW --sample <file.tsv>
+nextflow run SciLifeLab/CAW --sample <file.tsv> --step <step> --tools <tool>
 ```
 
-All variables and parameters are specified in the config (cf [configuration documentation](#profiles)).
+All parameters, options and variables can be specified with configuration files and profile (cf [configuration documentation](#profiles)).
 
-All samples are specified in the TSV files (cf [TSV documentation](TSV.md)).
+## Options
 
-## Steps
+### --callName `Name`
 
-Steps are used to configure which processes will be runned or skipped in the workflow. Different steps to be separated by commas. Possible values are:
+Specify a name for MultiQC report (optionnal)
+
+### --contactMail `email`
+
+Specify an email for MultiQC report (optionnal)
+
+### --help
+
+Display help
+
+### --project `ProjectID`
+
+Specify a project number ID on a UPPMAX cluster. (optionnal if not on such a cluster)
+
+### --sample `file.tsv`
+
+Use the given TSV file as sample (cf [TSV documentation](TSV.md)).
+
+### --step `step`
+
+Choose from wich step the workflow will start. Choose only one step. Possible values are:
 
 - preprocessing (default, will start workflow with FASTQ files)
 - realign (will start workflow with BAM files (with T/N BAMs that were not realigned together))
 - recalibrate (will start workflow with BAM files and Recalibration Tables (Only with T/N BAMs that were realigned together))
 - skipPreprocessing (will skip entire preprocessing (Only with T/N BAMs that were realigned together))
+
+### --test
+
+Test run CAW on a smaller dataset, that way you don't have to specify `--sample data/tsv/tiny.tsv --intervals repeats/tiny.list`
+
+### --tools `tool1[,tool2,tool3...]`
+
+Choose which tools will be used in the workflow. Different tools to be separated by commas. Possible values are:
+
+- Ascat (use ascat for CNV)
+- HaplotypeCaller (use HaplotypeCaller for VC)
+- Manta (use Manta for SV)
+- MultiQC (Make a QC report)
 - MuTect1 (use MuTect1 for VC)
 - MuTect2 (use MuTect2 for VC)
-- VarDict (use VarDict for VC)
 - Strelka (use Strelka for VC)
-- HaplotypeCaller (use HaplotypeCaller for normal bams VC)
-- Manta (use Manta for SV)
-- Ascat (use ascat for CNV)
-- MultiQC (Make a QC report)
+- VarDict (use VarDict for VC)
+- snpEff (use snpEff for Annotation)
 
-## Project
+### --verbose
 
-To specify your UPPMAX project number ID. It can also be specified in your `config` file (cf [configuration documentation](#profiles)).
+Display more information about files being processed.
 
-```bash
-nextflow run SciLifeLab/CAW --sample <file.tsv> --project <UPPMAX_Project>
-```
+### --version
 
-## Verbose
+Display version number and information.
 
-To have more information about files being processed, you can use the verbose option:
+## Parameters
+Simpler to specify in the config file.
 
-```bash
-nextflow run SciLifeLab/CAW --sample mysample.tsv --verbose
-```
+### --runTime `time`
+### --singleCPUMem `memory`
 
-## Test
+## References [(cf [References documentation](REFERENCES.md))]
+Could be usefull if you wish to change one reference for testing.
 
-To test CAW and run it on smaller dataset, use one of the following option:
+### --acLoci `file`
 
-- `--test` will test step `preprocessing` on tiny test data.
-- `--testRealign` will test step `realign` on tiny test data. Need to run `nextflow run SciLifeLab/CAW --test` before.
-- `--testCoreVC` will test steps `skipPreprocessing`, `MuTect1`, `Strelka` and `HaplotypeCaller` on tiny test data. Need to run `nextflow run SciLifeLab/CAW --test` before.
-- `--testSideVC` will test steps `skipPreprocessing`, `Ascat`, `Manta` and `HaplotypeCaller` on test downsampled set.
+## COSMIC files
+- --cosmic `file`
+- --cosmicIndex `file`
+
+### Files from the GATK Bundle
+- --dbsnp `file`
+- --dbsnpIndex `file`
+- --kgIndels `file`
+- --kgIndex `file`
+- --genome `file`
+- --genomeDict `file`
+- --genomeIndex `file`
+- --millsIndels `file`
+- --millsIndex `file`
+
+### BWA indexes
+- --genomeAmb `file`
+- --genomeAnn `file`
+- --genomeBwt `file`
+- --genomePac `file`
+- --genomeSa `file`
+
+## --intervals `file`
+
+## --snpeffDb `db`
+	Which database to use for snpEff
+
+## --vardictHome `path`
+	Path to Vardict
 
 # Nextflow options
 
@@ -86,7 +140,8 @@ If there is a feature or bugfix you want to use in a resumed or re-analyzed run,
 nextflow run -latest SciLifeLab/CAW --sample mysample.tsv -resume
 ```
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/doc/USAGE.md
+++ b/doc/USAGE.md
@@ -66,21 +66,26 @@ Display more information about files being processed.
 Display version number and information.
 
 ## Parameters
+
 Simpler to specify in the config file.
 
 ### --runTime `time`
+
 ### --singleCPUMem `memory`
 
 ## References [(cf [References documentation](REFERENCES.md))]
+
 Could be usefull if you wish to change one reference for testing.
 
 ### --acLoci `file`
 
 ## COSMIC files
+
 - --cosmic `file`
 - --cosmicIndex `file`
 
 ### Files from the GATK Bundle
+
 - --dbsnp `file`
 - --dbsnpIndex `file`
 - --kgIndels `file`
@@ -92,6 +97,7 @@ Could be usefull if you wish to change one reference for testing.
 - --millsIndex `file`
 
 ### BWA indexes
+
 - --genomeAmb `file`
 - --genomeAnn `file`
 - --genomeBwt `file`
@@ -101,10 +107,16 @@ Could be usefull if you wish to change one reference for testing.
 ## --intervals `file`
 
 ## --snpeffDb `db`
-	Which database to use for snpEff
+
+```
+Which database to use for snpEff
+```
 
 ## --vardictHome `path`
-	Path to Vardict
+
+```
+Path to Vardict
+```
 
 # Nextflow options
 

--- a/doc/USE_CASES.md
+++ b/doc/USE_CASES.md
@@ -1,16 +1,16 @@
 # Use cases
 
-The workflow has three pre-processing options: `preprocessing`, `realign` and `skipPreprocessing`. Using the `preprocessing` directive one will have a pair of mapped, deduplicated and recalibrated BAM files in the `Preprocessing/Recalibrated/` directory. Furthermore, during this process a deduplicated BAM file is created in the `Preprocessing/NonRealigned/` directory. This is the usual option you have to give when you are starting from raw FASTQ data:
+The workflow has four pre-processing options: `preprocessing`, `realign`, `recalibrate` and `skipPreprocessing`. Using the `preprocessing` directive one will have a pair of mapped, deduplicated and recalibrated BAM files in the `Preprocessing/Recalibrated/` directory. Furthermore, during this process a deduplicated BAM file is created in the `Preprocessing/NonRealigned/` directory. This is the usual option you have to give when you are starting from raw FASTQ data:
 
 ```bash
 nextflow run SciLifeLab/CAW --sample mysample.tsv
 ```
 
-Preprocessing will start by default, you do not have to give any additional steps, only the TSV file describing the sample (see below).
+Preprocessing will start by default, you do not have to give any additional parameters, only the TSV file describing the sample (see below).
 
 In the [default config file](../config/milou.config) we are defining the intervals file as well, this is used to define regions for variant call and realignment (in a scatter and gather fashion when possible). The intervals are chromosomes cut at their centromeres (so each chromosome arm processed separately) also additional unassigned contigs. We are ignoring the hs37d5 contig that contains concatenated decoy sequences.
 
-During processing steps a `trace.txt` and a `timeline.html` file is generated automatically. These files contain statistics about resources used and processes finished. If you start a new flow or restart/resume a sample, the previous version will be renamed as `trace.txt.1` and `timeline.html.1` respectively. Also, older version are renamed with incremented numbers.
+During the execution of the workflow a `trace.txt` and a `timeline.html` file is generated automatically. These files contain statistics about resources used and processes finished. If you start a new flow or restart/resume a sample, the previous version will be renamed as `trace.txt.1` and `timeline.html.1` respectively. Also, older version are renamed with incremented numbers.
 
 ## Starting from raw FASTQ - having pair of FASTQ files for normal and tumor samples (one lane for each sample)
 
@@ -65,7 +65,7 @@ SUBJECT_ID  XX    1    SAMPLEIDR    9    /samples/relapse9_1.fastq.gz    /sample
 NGI Production in the previous years delivered many preprocessed samples; these BAM files are not recalibrated. To have BAMs suitable for variant calling, realignement of pairs is necessary:
 
 ```bash
-nextflow run SciLifeLab/CAW --sample mysample.tsv --steps realign
+nextflow run SciLifeLab/CAW --sample mysample.tsv --step realign
 ```
 
 And the corresponding TSV file should be like:
@@ -77,12 +77,27 @@ SUBJECT_ID  XX    1    SAMPLEIDT    /samples/SAMPLEIDT.bam    /samples/SAMPLEIDT
 
 At the end of this step you should have recalibrated BAM files in the `Preprocessing/Recalibrated/` directory.
 
-## Starting from a recalibrated BAM file
+## Starting from recalibration
 
-At this step we are assuming that all the required preprocessing steps (alignment, deduplication, ..., recalibration) is over, we only want to run variant callers or other tools using recalibrated BAMs.
+If the bam files were realigned together, you can start from recalibration:
 
 ```bash
-nextflow run SciLifeLab/CAW --sample mysample.tsv --steps skipPreprocessing
+nextflow run SciLifeLab/CAW --sample mysample.tsv --step recalibrate
+```
+
+And the corresponding TSV file should be like:
+
+```
+SUBJECT_ID  XX    0    SAMPLEIDN    /samples/SAMPLEIDN.bam    /samples/SAMPLEIDN.bai /samples/SAMPLEIDN.recal.table
+SUBJECT_ID  XX    1    SAMPLEIDT    /samples/SAMPLEIDT.bam    /samples/SAMPLEIDT.bai /samples/SAMPLEIDT.recal.table
+```
+
+## Starting from a recalibrated BAM file
+
+At this step we are assuming that all the required preprocessing (alignment, deduplication, ..., recalibration) is over, we only want to run variant callers or other tools using recalibrated BAMs.
+
+```bash
+nextflow run SciLifeLab/CAW --sample mysample.tsv --step skipPreprocessing --tools <tool>
 ```
 
 And the corresponding TSV file should be like:
@@ -92,7 +107,8 @@ SUBJECT_ID  XX    0    SAMPLEIDN    /samples/SAMPLEIDN.bam    /samples/SAMPLEIDN
 SUBJECT_ID  XX    1    SAMPLEIDT    /samples/SAMPLEIDT.bam    /samples/SAMPLEIDT.bai
 ```
 
----
+--------------------------------------------------------------------------------
+
 [![](images/SciLifeLab_logo.png "SciLifeLab")][scilifelab-link] [![](images/NGI-final-small.png "NGI")][ngi-link]
 
 [ngi-link]: https://ngisweden.scilifelab.se/

--- a/main.nf
+++ b/main.nf
@@ -406,7 +406,7 @@ process RecalibrateBam {
     set idPatient, gender, status, idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bai") into recalibratedBam
     set idPatient, gender, status, idSample, val("${idSample}.recal.bam"), val("${idSample}.recal.bai") into recalibratedBamTSV
 
-  when: !'skipPreprocessing' in step
+  when: !('skipPreprocessing' in step)
 
   // TODO: ditto as at the previous BaseRecalibrator step, consider using -nct 4
   script:

--- a/main.nf
+++ b/main.nf
@@ -141,7 +141,7 @@ process RunFastQC {
 
 verbose ? fastQCreport = fastQCreport.view {"FastQC report: $it"} : ''
 
-referenceForMapReads = defineReferencesForProcess("MapReads")
+referenceForMapReads = defineReferenceForProcess("MapReads")
 
 process MapReads {
   tag {idPatient + "-" + idRun}

--- a/main.nf
+++ b/main.nf
@@ -56,7 +56,7 @@ vim: syntax=groovy
 
 revision = grabGitRevision()
 testFile = ''
-version = '1.0.5'
+version = '1.1'
 step = []
 tools = []
 

--- a/main.nf
+++ b/main.nf
@@ -1342,10 +1342,10 @@ def extractRecal(tsvFile) {
 def checkSteps(workflowSteps) {
   result = 0
 
-  result = 'preprocessing' in workflowSteps ? result++ : result
-  result = 'recalibrate' in workflowSteps ? result++ : result
-  result = 'realign' in workflowSteps ? result++ : result
-  result = 'skipPreprocessing' in workflowSteps ? result++ : result
+  'preprocessing' in workflowSteps ? result++ : ''
+  'recalibrate' in workflowSteps ? result++ : ''
+  'realign' in workflowSteps ? result++ : ''
+  'skipPreprocessing' in workflowSteps ? result++ : ''
 
   return result == 1 ? true : false
 }

--- a/main.nf
+++ b/main.nf
@@ -1260,7 +1260,7 @@ def checkFile(it) {
   catch (AssertionError ae) {
     exit 1, "Missing file in TSV file: $it, see --help for more information"
   }
-  return it
+  return file(it)
 }
 
 def checkTSV(it,number) {

--- a/main.nf
+++ b/main.nf
@@ -663,7 +663,7 @@ process RunMutect2 {
 mutect2Output = mutect2Output.groupTuple(by:[0,1,2,3,4])
 verbose ? mutect2Output = mutect2Output.view {"MuTect2 output: $it"} : ''
 
-defineReferenceForProcess("RunFreeBayes")
+referenceForRunFreeBayes = defineReferenceForProcess("RunFreeBayes")
 
 process RunFreeBayes {
   tag {idPatient + "-" + idSampleTumor + "-" + gen_int}

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,7 +58,6 @@ profiles {
     includeConfig 'configuration/standard.config'
   }
   docker_skadi {
-    includeConfig 'configuration/docker.config'
     includeConfig 'configuration/docker-skadi.config'
     includeConfig "$NXF_HOME/config"
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -11,8 +11,8 @@ vim: syntax=groovy
  */
 
 manifest {
-    homePage = 'http://github.com/SciLifeLab/CAW'
-    description = 'New Cancer Analysis Workflow from SciLifeLab'
+    homePage = 'http://opensource.scilifelab.se/projects/caw/'
+    description = 'Cancer Analysis Workflow'
 }
 
 params {
@@ -21,13 +21,9 @@ params {
   help = false
   project = ''
   sample = ''
-  steps = 'preprocessing'
+  step = 'preprocessing'
   tools = ''
   test = false
-  testRealign = false
-  testRecalibrate = false
-  testCoreVC = false
-  testSideVC = false
   vcflist =''
   verbose = false
   version = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -22,6 +22,7 @@ params {
   project = ''
   sample = ''
   steps = 'preprocessing'
+  tools = ''
   test = false
   testRealign = false
   testRecalibrate = false

--- a/test/test_skadi_docker.sh
+++ b/test/test_skadi_docker.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-nextflow run . -profile docker_skadi --test
-nextflow run . -profile docker_skadi --testRealign
-nextflow run . -profile docker_skadi --testRecalibrate
-nextflow run . -profile docker_skadi --testCoreVC
+nextflow run . -profile docker_skadi --test --steps preprocessing,MultiQC
+nextflow run . -profile docker_skadi --test --steps realign,MultiQC
+nextflow run . -profile docker_skadi --test --steps recalibrate,MultiQC
+nextflow run . -profile docker_skadi --test --steps skipPreprocessing,HaplotypeCaller,MuTect1,MuTect2

--- a/test/test_skadi_docker.sh
+++ b/test/test_skadi_docker.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 echo "Starting Nextflow... Command:"
-echo "nextflow run . -profile docker_skadi --test --steps preprocessing --tools MultiQC"
+echo "nextflow run . -profile docker_skadi --test --step preprocessing --tools MultiQC"
 echo "-----"
-nextflow run . -profile docker_skadi --test --steps preprocessing --tools MultiQC
+nextflow run . -profile docker_skadi --test --step preprocessing --tools MultiQC
 echo "Starting Nextflow... Command:"
-echo "nextflow run . -profile docker_skadi --test --steps realign --tools MultiQC"
+echo "nextflow run . -profile docker_skadi --test --step realign --tools MultiQC"
 echo "-----"
-nextflow run . -profile docker_skadi --test --steps realign --tools MultiQC
+nextflow run . -profile docker_skadi --test --step realign --tools MultiQC
 echo "Starting Nextflow... Command:"
-echo "nextflow run . -profile docker_skadi --test --steps recalibrate --tools MultiQC"
+echo "nextflow run . -profile docker_skadi --test --step recalibrate --tools MultiQC"
 echo "-----"
-nextflow run . -profile docker_skadi --test --steps recalibrate --tools MultiQC
+nextflow run . -profile docker_skadi --test --step recalibrate --tools MultiQC
 echo "Starting Nextflow... Command:"
-echo "nextflow run . -profile docker_skadi --test --steps skipPreprocessing --tools HaplotypeCaller,MuTect1,MuTect2"
+echo "nextflow run . -profile docker_skadi --test --step skipPreprocessing --tools HaplotypeCaller,MuTect1,MuTect2"
 echo "-----"
-nextflow run . -profile docker_skadi --test --steps skipPreprocessing --tools HaplotypeCaller,MuTect1,MuTect2
+nextflow run . -profile docker_skadi --test --step skipPreprocessing --tools HaplotypeCaller,MuTect1,MuTect2

--- a/test/test_skadi_docker.sh
+++ b/test/test_skadi_docker.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
-
-nextflow run . -profile docker_skadi --test --steps preprocessing,MultiQC
-nextflow run . -profile docker_skadi --test --steps realign,MultiQC
-nextflow run . -profile docker_skadi --test --steps recalibrate,MultiQC
-nextflow run . -profile docker_skadi --test --steps skipPreprocessing,HaplotypeCaller,MuTect1,MuTect2
+echo "Starting Nextflow... Command:"
+echo "nextflow run . -profile docker_skadi --test --steps preprocessing --tools MultiQC"
+echo "-----"
+nextflow run . -profile docker_skadi --test --steps preprocessing --tools MultiQC
+echo "Starting Nextflow... Command:"
+echo "nextflow run . -profile docker_skadi --test --steps realign --tools MultiQC"
+echo "-----"
+nextflow run . -profile docker_skadi --test --steps realign --tools MultiQC
+echo "Starting Nextflow... Command:"
+echo "nextflow run . -profile docker_skadi --test --steps recalibrate --tools MultiQC"
+echo "-----"
+nextflow run . -profile docker_skadi --test --steps recalibrate --tools MultiQC
+echo "Starting Nextflow... Command:"
+echo "nextflow run . -profile docker_skadi --test --steps skipPreprocessing --tools HaplotypeCaller,MuTect1,MuTect2"
+echo "-----"
+nextflow run . -profile docker_skadi --test --steps skipPreprocessing --tools HaplotypeCaller,MuTect1,MuTect2


### PR DESCRIPTION
/!\ WARNING /!\
Breaking compatibility with older version, so I propose to go directly to version 1.1

- Change --steps to --step and --tools
Only one step between `preprocessing`,`realilgn`,`recalibrate` and `skipPreprocessing`
And --tools to specify wich tools to be use.

Help updated.
Docker container updated.
Links to CAW website.

Refactoring:
- replace `workflowSteps` by `step` and `tools`
- add function `defineReferenceForProcess(process)` to define reference files for each process (the long term plan is to verify only the references needed and not all, and try to download/build them then if needed)
- rename `bam` to `mappedBam` to clarify code
- use `map.key` notation to access maps instead of `map['key']`
- Channels `duplicatesRealign` and `intervals` are now phased to bamsAndIntervals for `RealignBams` process
- use `mode flatten` for output of `RealignBams` process instead of the old ugly piece of code
- The workflow should now support multiple patients
- sorted functions by alphabetical order