### PR TITLE
Fix error message when no --tools parameter given

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -57,8 +57,6 @@ vim: syntax=groovy
 revision = grabGitRevision()
 testFile = ''
 version = '1.1'
-step = []
-tools = []
 
 if (!checkUppmaxProject()) {exit 1, 'No UPPMAX project ID found! Use --project <UPPMAX Project ID>'}
 
@@ -71,8 +69,8 @@ if (params.version) {
   exit 1
 }
 
-step = params.step ? params.step.split(',').collect {it.trim()} : ''
-tools = params.tools ? params.tools.split(',').collect {it.trim()} : ''
+step = params.step ? params.step.split(',').collect {it.trim()} : []
+tools = params.tools ? params.tools.split(',').collect {it.trim()} : []
 
 directoryMap = defineDirectoryMap()
 referenceMap = defineReferenceMap()


### PR DESCRIPTION
Problem:
```
nextflow run main.nf -profile localhost --test

ERROR ~ No signature of method: java.lang.String.join() is applicable for argument types: (java.lang.String) values: [, ]
Possible solutions: wait(), trim(), find(), wait(long), split(java.lang.String), count(java.lang.CharSequence)

 -- Check script 'main.nf' at line: 1553 or see '.nextflow.log' file for more details
```
Line 1553 contains `tools.join(...)`. If no `--tools` was given on the command-line,
then tools is an empty string (`''`). An empty string does not have a `.join` method.