### PR TITLE
corrected condition for extra for cancer sample in BWA

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -163,7 +163,7 @@ process MapReads {
   script:
   readGroup = "@RG\\tID:$idRun\\tSM:$idSample\\tLB:$idSample\\tPL:illumina"
   // adjust mismatch penalty for tumor samples
-  extra = status == 1 ? "-B 3 " : ""
+  extra = status == "1" ? "-B 3 " : ""
   """
   set -eo pipefail
   bwa mem -R \"$readGroup\" ${extra}-t $task.cpus -M \


### PR DESCRIPTION
`status` is a string, so all samples were processed without `-B 3`