### PR TITLE
Simplify genome configuration

### DIFF
--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -139,31 +139,5 @@ process {
 }
 
 params {
-  // Change the files/directories according to your local setup
   singleCPUMem  = 8.GB
-  genome = 'GRCh37'
-  genomes {
-    'GRCh37' {
-      acLoci        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase3_20130502_SNP_maf0.3.loci'
-      cosmic        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/b37_cosmic_v74.noCHR.sort.4.1.vcf'
-      cosmicIndex   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/b37_cosmic_v74.noCHR.sort.4.1.vcf.idx'
-      dbsnp         = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/dbsnp_138.b37.vcf'
-      dbsnpIndex    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/dbsnp_138.b37.vcf.idx'
-      genome        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta'
-      genomeAmb     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.amb'
-      genomeAnn     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.ann'
-      genomeBwt     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.bwt'
-      genomeDict    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.dict'
-      genomeIndex   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.fai'
-      genomePac     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.pac'
-      genomeSa      = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.sa'
-      intervals     = "/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/centromeres.list"
-      kgIndels      = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase1.indels.b37.vcf'
-      kgIndex       = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase1.indels.b37.vcf.idx'
-      millsIndels   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/Mills_and_1000G_gold_standard.indels.b37.vcf'
-      millsIndex    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx'
-      snpeffDb      = 'GRCh37.75'
-      vardictHome   = '/sw/apps/bioinfo/VarDictJava/1.4.5/milou/VarDictJava/'
-    }
-  }
 }

--- a/configuration/uppmax-genomes.config
+++ b/configuration/uppmax-genomes.config
@@ -1,0 +1,39 @@
+/*
+vim: syntax=groovy
+-*- mode: groovy;-*-
+ * -------------------------------------------------
+ * Nextflow config file for CAW project
+ * working on UPPMAX clusters
+ * -------------------------------------------------
+ */
+
+params {
+  genome = 'GRCh37'
+  genomes {
+    'GRCh37' {
+      bundleDir     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37'
+      acLoci        = "$bundleDir/1000G_phase3_20130502_SNP_maf0.3.loci"
+      cosmic        = "$bundleDir/b37_cosmic_v74.noCHR.sort.4.1.vcf"
+      genome        = "$bundleDir/human_g1k_v37_decoy.fasta"
+      dbsnp         = "$bundleDir/dbsnp_138.b37.vcf"
+      genomeDict    = "$bundleDir/human_g1k_v37_decoy.dict"
+      intervals     = "$bundleDir/centromeres.list"
+      kgIndels      = "$bundleDir/1000G_phase1.indels.b37.vcf"
+      millsIndels   = "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf"
+      snpeffDb      = "GRCh37.75"
+      vardictHome   = "/sw/apps/bioinfo/VarDictJava/1.4.5/milou/VarDictJava/"
+
+      genomeAmb     = "${genome}.amb"
+      genomeAnn     = "${genome}.ann"
+      genomeBwt     = "${genome}.bwt"
+      genomeIndex   = "${genome}.fai"
+      genomePac     = "${genome}.pac"
+      genomeSa      = "${genome}.sa"
+      genomeAlt     = ""
+      cosmicIndex   = "${cosmic}.idx"
+      dbsnpIndex    = "${dbsnp}.idx"
+      kgIndex       = "${kgIndels}.idx"
+      millsIndex    = "${millsIndels}.idx"
+    }
+  }
+}

--- a/configuration/uppmax.config
+++ b/configuration/uppmax.config
@@ -130,31 +130,3 @@ process {
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }
-
-params {
-  genome = 'GRCh37'
-  genomes {
-    'GRCh37' {
-      acLoci        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase3_20130502_SNP_maf0.3.loci'
-      cosmic        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/b37_cosmic_v74.noCHR.sort.4.1.vcf'
-      cosmicIndex   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/b37_cosmic_v74.noCHR.sort.4.1.vcf.idx'
-      dbsnp         = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/dbsnp_138.b37.vcf'
-      dbsnpIndex    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/dbsnp_138.b37.vcf.idx'
-      genome        = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta'
-      genomeAmb     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.amb'
-      genomeAnn     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.ann'
-      genomeBwt     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.bwt'
-      genomeDict    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.dict'
-      genomeIndex   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.fai'
-      genomePac     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.pac'
-      genomeSa      = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/human_g1k_v37_decoy.fasta.sa'
-      intervals     = "/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/centromeres.list"
-      kgIndels      = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase1.indels.b37.vcf'
-      kgIndex       = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/1000G_phase1.indels.b37.vcf.idx'
-      millsIndels   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/Mills_and_1000G_gold_standard.indels.b37.vcf'
-      millsIndex    = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37/Mills_and_1000G_gold_standard.indels.b37.vcf.idx'
-      snpeffDb      = 'GRCh37.75'
-      vardictHome   = '/sw/apps/bioinfo/VarDictJava/1.4.5/milou/VarDictJava/'
-    }
-  }
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -33,15 +33,18 @@ profiles {
   standard {
     includeConfig 'configuration/uppmax.config'
     includeConfig 'configuration/uppmax-slurm.config'
+    includeConfig 'configuration/uppmax-genomes.config'
     includeConfig 'configuration/standard.config'
   }
   interactive {
     includeConfig 'configuration/uppmax.config'
+    includeConfig 'configuration/uppmax-genomes.config'
     includeConfig 'configuration/milou-local.config'
     includeConfig 'configuration/standard.config'
   }
   localhost {
     includeConfig 'configuration/localhost.config'
+    includeConfig 'configuration/uppmax-genomes.config'
     includeConfig 'configuration/standard.config'
   }
   docker {


### PR DESCRIPTION
Simplified configuration of bundle paths by using string interpolation, and also put everything into a single file that is then included by all the profiles that need it.