### PR TITLE
ALT-aware mapping

### DIFF
--- a/configuration/uppmax-genomes.config
+++ b/configuration/uppmax-genomes.config
@@ -23,13 +23,8 @@ params {
       snpeffDb      = "GRCh37.75"
       vardictHome   = "/sw/apps/bioinfo/VarDictJava/1.4.5/milou/VarDictJava/"
 
-      genomeAmb     = "${genome}.amb"
-      genomeAnn     = "${genome}.ann"
-      genomeBwt     = "${genome}.bwt"
+      bwaIndex      = "${genome}.*"  // this includes a few extra files not needed by BWA
       genomeIndex   = "${genome}.fai"
-      genomePac     = "${genome}.pac"
-      genomeSa      = "${genome}.sa"
-      genomeAlt     = ""
       cosmicIndex   = "${cosmic}.idx"
       dbsnpIndex    = "${dbsnp}.idx"
       kgIndex       = "${kgIndels}.idx"
@@ -47,14 +42,9 @@ params {
       millsIndels   = "/dev/null"
       snpeffDb      = "/dev/null"
       vardictHome   = "/dev/null"
+      bwaIndex      = "${genome}.64.*"
 
       genomeIndex   = "${genome}.fai"
-      genomeAmb     = "${genome}.64.amb"
-      genomeAnn     = "${genome}.64.ann"
-      genomeBwt     = "${genome}.64.bwt"
-      genomePac     = "${genome}.64.pac"
-      genomeSa      = "${genome}.64.sa"
-      genomeAlt     = "${genome}.64.alt"  // TODO actually use this
       cosmicIndex   = "/dev/null" //"${cosmic}.idx"
       dbsnpIndex    = "/dev/null" //"${dbsnp}.idx"
       kgIndex       = "/dev/null" //"${kgIndels}.idx"

--- a/main.nf
+++ b/main.nf
@@ -156,7 +156,7 @@ process MapReads {
 
   input:
     set idPatient, gender, status, idSample, idRun, file(fastqFile1), file(fastqFile2) from fastqFiles
-    set file(genomeAmb), file(genomeAnn), file(genomeBwt), file(genomeFile), file(genomeIndex), file(genomePac), file(genomeSa) from referenceForMapReads
+    set file(genomeFile), file(bwaIndex) from referenceForMapReads
 
   output:
     set idPatient, gender, status, idSample, idRun, file("${idRun}.bam") into mappedBam
@@ -1165,8 +1165,11 @@ def checkReferenceMap(referenceMap) {
 }
 
 def checkRefExistence(referenceFile, fileToCheck) {
-  // Check file existence
-  if (!file(fileToCheck).exists()) {
+  def f = file(fileToCheck)
+  if (f instanceof List && f.size() > 0) {
+    // this is an expanded wildcard: we can assume all files exist
+    return true
+  } else if (!f.exists()) {
     log.info  "Missing references: $referenceFile $fileToCheck"
     return false
   }
@@ -1226,13 +1229,8 @@ def defineDirectoryMap() {
 def defineReferenceForProcess(process) {
   if (process == "MapReads") {
     return Channel.from (
-      file(referenceMap.genomeAmb),
-      file(referenceMap.genomeAnn),
-      file(referenceMap.genomeBwt),
       file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomePac),
-      file(referenceMap.genomeSa)
+      file(referenceMap.bwaIndex),
     ).toList()
   } else if (process == "CreateIntervals") {
     return Channel.from (
@@ -1350,22 +1348,14 @@ def defineReferenceMap() {
     'cosmicIndex' : params.genome ? params.genomes[params.genome].cosmicIndex ?: false : false,
     // dbSNP index
     'dbsnpIndex'  : params.genome ? params.genomes[params.genome].dbsnpIndex ?: false : false,
-    // BWA indexes
-    'genomeAmb'   : params.genome ? params.genomes[params.genome].genomeAmb ?: false : false,
-    // BWA indexes
-    'genomeAnn'   : params.genome ? params.genomes[params.genome].genomeAnn ?: false : false,
-    // BWA indexes
-    'genomeBwt'   : params.genome ? params.genomes[params.genome].genomeBwt ?: false : false,
     // genome reference dictionary
     'genomeDict'  : params.genome ? params.genomes[params.genome].genomeDict ?: false : false,
     // genome reference
     'genomeFile'  : params.genome ? params.genomes[params.genome].genome ?: false : false,
     // genome reference index
     'genomeIndex' : params.genome ? params.genomes[params.genome].genomeIndex ?: false : false,
-    // BWA indexes
-    'genomePac'   : params.genome ? params.genomes[params.genome].genomePac ?: false : false,
-    // BWA indexes
-    'genomeSa'    : params.genome ? params.genomes[params.genome].genomeSa ?: false : false,
+    // BWA index
+    'bwaIndex'    : params.genome ? params.genomes[params.genome].bwaIndex ?: false : false,
     // intervals file for spread-and-gather processes (usually chromosome chunks at centromeres)
     'intervals'   : params.genome ? params.genomes[params.genome].intervals ?: false : false,
     // 1000 Genomes SNPs

--- a/main.nf
+++ b/main.nf
@@ -1158,13 +1158,10 @@ def checkParameterList(list, realList) {
 
 def checkReferenceMap(referenceMap) {
   // Loop through all the references files to check their existence
-  final referenceDefined = true
-  referenceMap.each{
+  referenceMap.every {
     referenceFile, fileToCheck ->
-    final test = checkRefExistence(referenceFile, fileToCheck)
-    !(test) ? referenceDefined = false : ''
+    checkRefExistence(referenceFile, fileToCheck)
   }
-  return referenceDefined
 }
 
 def checkRefExistence(referenceFile, fileToCheck) {


### PR DESCRIPTION
The index files are now defined through a path with wildcards. They are no longer listed one by one, which makes it possible to have the GRCh37 version without and the GRCh38 with the .alt index file. This also simplifies the configuration.

With this change, BWA-MEM will run in ALT-aware mode.

This PR breaks the docker configuration files, but I will leave that to @MaxUlysse, who is working on #240 anyway.