### PR TITLE
Flexible indel list

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -35,25 +35,24 @@ params {
       ]
       snpeffDb    = "GRCh37.75"
     }
-  'GRCh38' {
-    acLoci        = "/dev/null"
-    cosmic        = "/dev/null"
-    cosmicIndex   = "/dev/null" //"${cosmic}.idx"
-    dbsnp         = "$bundleDir/dbsnp_146.hg38.vcf.gz"
-    dbsnpIndex    = "${dbsnp}.tbi"
-    genome        = "$bundleDir/Homo_sapiens_assembly38.fasta"
-    bwaIndex      = "${genome}.64.*"
-    genomeDict    = "$bundleDir/Homo_sapiens_assembly38.dict"
-    genomeIndex   = "${genome}.fai"
-    bwaIndex      = "${genome}.64.{amb,ann,bwt,pac,sa,alt}"
-    intervals     = "$bundleDir/wgs_calling_regions.hg38.interval_list"  // TODO different format
-    knownIndels   = [  // TODO which other VCFs should be included?
-      "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-    ]
-    knownIndelsIndex = [
-      "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
-    ]
-    snpeffDb      = "GRCh38"
+    'GRCh38' {
+      acLoci        = "/dev/null"
+      cosmic        = "/dev/null"
+      cosmicIndex   = "/dev/null" //"${cosmic}.idx"
+      dbsnp         = "$bundleDir/dbsnp_146.hg38.vcf.gz"
+      dbsnpIndex    = "${dbsnp}.tbi"
+      genome        = "$bundleDir/Homo_sapiens_assembly38.fasta"
+      genomeDict    = "$bundleDir/Homo_sapiens_assembly38.dict"
+      genomeIndex   = "${genome}.fai"
+      bwaIndex      = "${genome}.64.{amb,ann,bwt,pac,sa,alt}"
+      intervals     = "$bundleDir/wgs_calling_regions.hg38.interval_list"  // TODO different format
+      knownIndels   = [  // TODO which other VCFs should be included?
+        "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+      ]
+      knownIndelsIndex = [
+        "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
+      ]
+      snpeffDb      = "GRCh38"
     }
   }
 }

--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -21,12 +21,18 @@ params {
       dbsnp       = "$bundleDir/dbsnp_138.b37.vcf"
       dbsnpIndex  = "${dbsnp}.idx"
       genome      = "$bundleDir/human_g1k_v37_decoy.fasta"
-      bwaIndex    = "${genome}.{alt,amb,ann,bwt,pac,sa}"
+      bwaIndex    = "${genome}.{amb,ann,bwt,pac,sa}"
       genomeDict  = "$bundleDir/human_g1k_v37_decoy.dict"
       genomeIndex = "${genome}.fai"
       intervals   = "$bundleDir/centromeres.list"
-      knownIndels = ["$bundleDir/1000G_phase1.indels.b37.vcf", "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf"]
-      knownIndelsIndex = ["$bundleDir/1000G_phase1.indels.b37.vcf.idx", "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf.idx"]
+      knownIndels = [
+        "$bundleDir/1000G_phase1.indels.b37.vcf",
+        "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf"
+      ]
+      knownIndelsIndex = [
+        "$bundleDir/1000G_phase1.indels.b37.vcf.idx",
+        "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf.idx"
+      ]
       snpeffDb    = "GRCh37.75"
     }
   'GRCh38' {
@@ -34,16 +40,19 @@ params {
     cosmic        = "/dev/null"
     cosmicIndex   = "/dev/null" //"${cosmic}.idx"
     dbsnp         = "$bundleDir/dbsnp_146.hg38.vcf.gz"
-    dbsnpIndex    = "/dev/null" //"${dbsnp}.idx"
+    dbsnpIndex    = "${dbsnp}.tbi"
     genome        = "$bundleDir/Homo_sapiens_assembly38.fasta"
     bwaIndex      = "${genome}.64.*"
     genomeDict    = "$bundleDir/Homo_sapiens_assembly38.dict"
     genomeIndex   = "${genome}.fai"
+    bwaIndex      = "${genome}.64.{amb,ann,bwt,pac,sa,alt}"
     intervals     = "$bundleDir/wgs_calling_regions.hg38.interval_list"  // TODO different format
-    kgIndels      = "/dev/null"
-    kgIndex       = "/dev/null" //"${kgIndels}.idx"
-    millsIndels   = "/dev/null"
-    millsIndex    = "/dev/null" //${millsIndels}.idx"
+    knownIndels   = [  // TODO which other VCFs should be included?
+      "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+    ]
+    knownIndelsIndex = [
+      "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
+    ]
     snpeffDb      = "GRCh38"
     }
   }

--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -25,10 +25,8 @@ params {
       genomeDict  = "$bundleDir/human_g1k_v37_decoy.dict"
       genomeIndex = "${genome}.fai"
       intervals   = "$bundleDir/centromeres.list"
-      kgIndels    = "$bundleDir/1000G_phase1.indels.b37.vcf"
-      kgIndex     = "${kgIndels}.idx"
-      millsIndels = "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf"
-      millsIndex  = "${millsIndels}.idx"
+      knownIndels = ["$bundleDir/1000G_phase1.indels.b37.vcf", "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf"]
+      knownIndelsIndex = ["$bundleDir/1000G_phase1.indels.b37.vcf.idx", "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf.idx"]
       snpeffDb    = "GRCh37.75"
     }
   'GRCh38' {

--- a/main.nf
+++ b/main.nf
@@ -1232,103 +1232,103 @@ def defineDirectoryMap() {
 def defineReferenceForProcess(process) {
   if (process == "MapReads") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.bwaIndex),
+      referenceMap.genomeFile,
+      referenceMap.bwaIndex
     ).toList()
   } else if (process == "CreateIntervals") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict),
-      referenceMap.knownIndels.collect{file(it)},
-      referenceMap.knownIndelsIndex.collect{file(it)},
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict,
+      referenceMap.knownIndels,
+      referenceMap.knownIndelsIndex
     ).toList()
   } else if (process == "RealignBams") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict),
-      referenceMap.knownIndels.collect{file(it)},
-      referenceMap.knownIndelsIndex.collect{file(it)},
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict,
+      referenceMap.knownIndels,
+      referenceMap.knownIndelsIndex
     ).toList()
   } else if (process == "CreateRecalibrationTable") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict),
-      file(referenceMap.dbsnp),
-      file(referenceMap.dbsnpIndex),
-      referenceMap.knownIndels.collect{file(it)},
-      referenceMap.knownIndelsIndex.collect{file(it)},
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict,
+      referenceMap.dbsnp,
+      referenceMap.dbsnpIndex,
+      referenceMap.knownIndels,
+      referenceMap.knownIndelsIndex
     ).toList()
   } else if (process == "RecalibrateBam") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict
     ).toList()
   } else if (process == "RunHaplotypecaller") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict),
-      file(referenceMap.dbsnp),
-      file(referenceMap.dbsnpIndex)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict,
+      referenceMap.dbsnp,
+      referenceMap.dbsnpIndex
     ).toList()
   } else if (process == "RunMutect1") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict),
-      file(referenceMap.dbsnp),
-      file(referenceMap.dbsnpIndex),
-      file(referenceMap.cosmic),
-      file(referenceMap.cosmicIndex)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict,
+      referenceMap.dbsnp,
+      referenceMap.dbsnpIndex,
+      referenceMap.cosmic,
+      referenceMap.cosmicIndex
     ).toList()
   } else if (process == "RunMutect2") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict),
-      file(referenceMap.dbsnp),
-      file(referenceMap.dbsnpIndex),
-      file(referenceMap.cosmic),
-      file(referenceMap.cosmicIndex)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict,
+      referenceMap.dbsnp,
+      referenceMap.dbsnpIndex,
+      referenceMap.cosmic,
+      referenceMap.cosmicIndex
     ).toList()
   } else if (process == "RunFreeBayes") {
     return Channel.from (
-      file(referenceMap.genomeFile)
+      referenceMap.genomeFile
     )
   } else if (process == "RunVardict") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict
     ).toList()
   } else if (process == "ConcatVCF") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict
     ).toList()
 
   } else if (process == "RunStrelka") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict
     ).toList()
   } else if (process == "RunManta") {
     return Channel.from (
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex)
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex
     ).toList()
   } else if (process == "RunAlleleCount") {
     return Channel.from (
-      file(referenceMap.acLoci),
-      file(referenceMap.genomeFile),
-      file(referenceMap.genomeIndex),
-      file(referenceMap.genomeDict)
+      referenceMap.acLoci,
+      referenceMap.genomeFile,
+      referenceMap.genomeIndex,
+      referenceMap.genomeDict
     ).toList()
   } else return null
 }
@@ -1340,21 +1340,21 @@ def defineReferenceMap() {
   genome = params.genomes[params.genome]
 
   return [
-    'acLoci'      : genome.acLoci,  // loci file for ascat
-    'dbsnp'       : genome.dbsnp,
-    'dbsnpIndex'  : genome.dbsnpIndex,
-    'cosmic'      : genome.cosmic,  // cosmic VCF with VCF4.1 header
-    'cosmicIndex' : genome.cosmicIndex,
-    'genomeDict'  : genome.genomeDict,  // genome reference dictionary
-    'genomeFile'  : genome.genome,  // FASTA genome reference
-    'genomeIndex' : genome.genomeIndex,  // genome .fai file
-    'bwaIndex'    : genome.bwaIndex,  // BWA index files
+    'acLoci'      : file(genome.acLoci),  // loci file for ascat
+    'dbsnp'       : file(genome.dbsnp),
+    'dbsnpIndex'  : file(genome.dbsnpIndex),
+    'cosmic'      : file(genome.cosmic),  // cosmic VCF with VCF4.1 header
+    'cosmicIndex' : file(genome.cosmicIndex),
+    'genomeDict'  : file(genome.genomeDict),  // genome reference dictionary
+    'genomeFile'  : file(genome.genome),  // FASTA genome reference
+    'genomeIndex' : file(genome.genomeIndex),  // genome .fai file
+    'bwaIndex'    : file(genome.bwaIndex),  // BWA index files
     // intervals file for spread-and-gather processes (usually chromosome chunks at centromeres)
-    'intervals'   : genome.intervals,
-    'vardictHome' : genome.vardictHome,  // path to VarDict
+    'intervals'   : file(genome.intervals),
+    'vardictHome' : file(genome.vardictHome),  // path to VarDict
     // VCFs with known indels (such as 1000 Genomes, Mill’s gold standard)
-    'knownIndels' : genome.knownIndels,
-    'knownIndelsIndex': genome.knownIndelsIndex,
+    'knownIndels' : genome.knownIndels.collect{file(it)},
+    'knownIndelsIndex': genome.knownIndelsIndex.collect{file(it)},
   ]
 }
 

--- a/main.nf
+++ b/main.nf
@@ -1337,37 +1337,28 @@ def defineReferenceForProcess(process) {
 }
 
 def defineReferenceMap() {
+  if (!(params.genome in params.genomes)) {
+    exit 1, "Genome $params.genome not found in configuration"
+  }
+  genome = params.genomes[params.genome]
+
   return [
-    // loci file for ascat
-    'acLoci'      : params.genome ? params.genomes[params.genome].acLoci ?: false : false,
-    // dbSNP
-    'dbsnp'       : params.genome ? params.genomes[params.genome].dbsnp ?: false : false,
-    // cosmic vcf file with VCF4.1 header
-    'cosmic'      : params.genome ? params.genomes[params.genome].cosmic ?: false : false,
-    // cosmic vcf file index
-    'cosmicIndex' : params.genome ? params.genomes[params.genome].cosmicIndex ?: false : false,
-    // dbSNP index
-    'dbsnpIndex'  : params.genome ? params.genomes[params.genome].dbsnpIndex ?: false : false,
-    // genome reference dictionary
-    'genomeDict'  : params.genome ? params.genomes[params.genome].genomeDict ?: false : false,
-    // genome reference
-    'genomeFile'  : params.genome ? params.genomes[params.genome].genome ?: false : false,
-    // genome reference index
-    'genomeIndex' : params.genome ? params.genomes[params.genome].genomeIndex ?: false : false,
-    // BWA index
-    'bwaIndex'    : params.genome ? params.genomes[params.genome].bwaIndex ?: false : false,
+    'acLoci'      : genome.acLoci,  // loci file for ascat
+    'dbsnp'       : genome.dbsnp,
+    'dbsnpIndex'  : genome.dbsnpIndex,
+    'cosmic'      : genome.cosmic,  // cosmic VCF file with VCF4.1 header
+    'cosmicIndex' : genome.cosmicIndex,
+    'genomeDict'  : genome.genomeDict,  // genome reference dictionary
+    'genomeFile'  : genome.genome,  // FASTA genome reference
+    'genomeIndex' : genome.genomeIndex,  // genome .fai file
+    'bwaIndex'    : genome.bwaIndex,  // BWA index files
     // intervals file for spread-and-gather processes (usually chromosome chunks at centromeres)
-    'intervals'   : params.genome ? params.genomes[params.genome].intervals ?: false : false,
-    // 1000 Genomes SNPs
-    'kgIndels'    : params.genome ? params.genomes[params.genome].kgIndels ?: false : false,
-    // 1000 Genomes SNPs index
-    'kgIndex'     : params.genome ? params.genomes[params.genome].kgIndex ?: false : false,
-    // Mill's Golden set of SNPs
-    'millsIndels' : params.genome ? params.genomes[params.genome].millsIndels ?: false : false,
-    // Mill's Golden set index
-    'millsIndex'  : params.genome ? params.genomes[params.genome].millsIndex ?: false : false,
-    // path to VarDict
-    'vardictHome' : params.genome ? params.genomes[params.genome].vardictHome ?: false : false
+    'intervals'   : genome.intervals,
+    'vardictHome' : genome.vardictHome,  // path to VarDict
+    'kgIndels'    : genome.kgIndels,  // 1000 Genomes
+    'kgIndex'     : genome.kgIndex,
+    'millsIndels' : genome.millsIndels,  // Mill's Golden set of SNPs
+    'millsIndex'  : genome.millsIndex,
   ]
 }
 


### PR DESCRIPTION
Merge configuration settings kgIndels and millsIndels into a single knownIndels, which is a list of VCF file names. We need this flexibility for other references such as GRCh38 which do not necessarily have the same number of VCF files with known indels.

See other commit messages for more changes.