### PR TITLE
Use same known indels for GRCh38 as Broad

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -46,11 +46,13 @@ params {
       genomeIndex   = "${genome}.fai"
       bwaIndex      = "${genome}.64.{amb,ann,bwt,pac,sa,alt}"
       intervals     = "$bundleDir/wgs_calling_regions.hg38.interval_list"  // TODO different format
-      knownIndels   = [  // TODO which other VCFs should be included?
+      knownIndels   = [
         "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
+        "$bundleDir/beta/Homo_sapiens_assembly38.known_indels.vcf.gz"
       ]
       knownIndelsIndex = [
         "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
+        "$bundleDir/beta/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
       ]
       snpeffDb      = "GRCh38"
     }


### PR DESCRIPTION
According to the (probably outdated) workflow at
https://github.com/broadinstitute/wdl/blob/7e6f95b09221658911c35547b9ba5031013b7a63/scripts/broad_pipelines/PublicPairedSingleSampleWf_160927.inputs.json
they use Mills_and_1000G_gold_standard.indels.hg38.vcf.gz and
Homo_sapiens_assembly38.known_indels.vcf.gz as known indel VCFs.
Unfortunately, the latter file is in the beta/ subdirectory of their
hg38bundle, whatever that means.