### PR TITLE
 Ensure errors make the pipeline fail more consistently

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -791,24 +791,24 @@ process ConcatVCF {
     """
 
   else if (variantCaller == 'mutect2' || variantCaller == 'mutect1' || variantCaller == 'haplotypecaller' || variantCaller == 'freebayes')
-	"""
-	set -euo pipefail
-	# first make a header from one of the VCF intervals
-	# get rid of interval information only from the GATK command-line, but leave the rest
-	awk '/^#/{print}' `ls *vcf| head -1` | \
-	awk '!/GATKCommandLine/{print}/GATKCommandLine/{for(i=1;i<=NF;i++){if(\$i!~/intervals=/ && \$i !~ /out=/){printf("%s ",\$i)}}printf("\\n")}' \
-	> header
+    """
+    set -euo pipefail
+    # first make a header from one of the VCF intervals
+    # get rid of interval information only from the GATK command-line, but leave the rest
+    awk '/^#/{print}' `ls *vcf| head -1` | \
+    awk '!/GATKCommandLine/{print}/GATKCommandLine/{for(i=1;i<=NF;i++){if(\$i!~/intervals=/ && \$i !~ /out=/){printf("%s ",\$i)}}printf("\\n")}' \
+    > header
 
-	## concatenate calls
-	rm -rf raw_calls
-	for f in *vcf; do
-		awk '!/^#/{print}' \$f >> raw_calls
-	done
-	cat header raw_calls > unsorted.vcf
-	java -jar \${PICARD_HOME}/picard.jar SortVcf I=unsorted.vcf O=$outputFile
-	rm unsorted.vcf
-	gzip -v $outputFile
-	"""
+    ## concatenate calls
+    rm -rf raw_calls
+    for f in *vcf; do
+      awk '!/^#/{print}' \$f >> raw_calls
+    done
+    cat header raw_calls > unsorted.vcf
+    java -jar \${PICARD_HOME}/picard.jar SortVcf I=unsorted.vcf O=$outputFile
+    rm unsorted.vcf
+    gzip -v $outputFile
+    """
 }
 
 verbose ? vcfConcatenated = vcfConcatenated.view {"VCF concatenated: $it"} : ''
@@ -1490,7 +1490,7 @@ def generateIntervalsForVC(bams, gI) {
 }
 
 def grabRevision() {
-	return workflow.revision ?: workflow.scriptId.substring(0,10)
+  return workflow.revision ?: workflow.scriptId.substring(0,10)
 }
 
 def help_message(version, revision) { // Display help message

--- a/main.nf
+++ b/main.nf
@@ -168,7 +168,7 @@ process MapReads {
   // adjust mismatch penalty for tumor samples
   extra = status == 1 ? "-B 3 " : ""
   """
-  set -eo pipefail
+  set -euo pipefail
   bwa mem -R \"$readGroup\" ${extra}-t $task.cpus -M \
   $genomeFile $fastqFile1 $fastqFile2 | \
   samtools sort --threads $task.cpus - > ${idRun}.bam
@@ -781,6 +781,7 @@ process ConcatVCF {
 
   if (variantCaller == 'vardict')
     """
+    set -euo pipefail
     for i in $vcFiles ;do
       cat \$i | ${referenceMap.vardictHome}/VarDict/testsomatic.R >> testsomatic.out
     done
@@ -791,6 +792,7 @@ process ConcatVCF {
 
   else if (variantCaller == 'mutect2' || variantCaller == 'mutect1' || variantCaller == 'haplotypecaller' || variantCaller == 'freebayes')
 	"""
+	set -euo pipefail
 	# first make a header from one of the VCF intervals
 	# get rid of interval information only from the GATK command-line, but leave the rest
 	awk '/^#/{print}' `ls *vcf| head -1` | \
@@ -831,6 +833,7 @@ process RunStrelka {
 
   script:
   """
+  set -euo pipefail
   tumorPath=`readlink $bamTumor`
   normalPath=`readlink $bamNormal`
   genomeFile=`readlink $genomeFile`
@@ -1075,6 +1078,7 @@ process RunSnpeff {
 
   script:
   """
+  set -euo pipefail
   java -Xmx${task.memory.toGiga()}g \
   -jar \$SNPEFF_HOME/snpEff.jar \
   $snpeffDb \


### PR DESCRIPTION
... by adding a few more `set -euo pipefail` where they did not exist, yet. The second commit converts some stray tabs to spaces.