### PR TITLE
Clearer naming of some GATK processes

### DIFF
--- a/configuration/docker.config
+++ b/configuration/docker.config
@@ -50,7 +50,7 @@ process {
   $ConcatVCF {
     container = 'maxulysse/concatvcf:1.1'
   }
-  $CreateIntervals {
+  $RealignerTargetCreator {
     container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
   }
@@ -74,7 +74,7 @@ process {
     cpus = 1
     memory = {params.singleCPUMem * task.attempt}
   }
-  $RealignBams {
+  $IndelRealigner {
     container = 'maxulysse/gatk:1.1'
     time = {params.runTime * task.attempt}
   }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -58,12 +58,12 @@ process {
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
-  $CreateIntervals {
+  $RealignerTargetCreator {
     module = ['bioinfo-tools', 'java/sun_jdk1.8.0_92', 'GATK/3.7']
     memory = {params.singleCPUMem * 4 * task.attempt}
     cpus = 4
   }
-  $RealignBams {
+  $IndelRealigner {
     module = ['bioinfo-tools', 'java/sun_jdk1.8.0_92', 'GATK/3.7']
     cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}

--- a/configuration/uppmax-slurm.config
+++ b/configuration/uppmax-slurm.config
@@ -20,7 +20,7 @@ process {
 
   // specific queue for specific processes
   $MergeBams.queue = 'core'
-  $RealignBams.queue = 'core'
+  $IndelRealigner.queue = 'core'
   $CreateRecalibrationTable.queue = 'core'
   $RecalibrateBam.queue = 'core'
   $MarkDuplicates.queue = 'core'

--- a/configuration/uppmax.config
+++ b/configuration/uppmax.config
@@ -52,11 +52,11 @@ process {
     cpus = 1
     memory = {params.singleCPUMem * 8 * task.attempt}
   }
-  $CreateIntervals {
+  $RealignerTargetCreator {
     module = ['bioinfo-tools', 'java/sun_jdk1.8.0_92', 'GATK/3.7']
     time = {params.runTime * task.attempt}
   }
-  $RealignBams {
+  $IndelRealigner {
     module = ['bioinfo-tools', 'java/sun_jdk1.8.0_92', 'GATK/3.7']
     time = {params.runTime * task.attempt}
     cpus = 1

--- a/main.nf
+++ b/main.nf
@@ -30,8 +30,8 @@ vim: syntax=groovy
  - MapReads - Map reads
  - MergeBams - Merge BAMs if multilane samples
  - MarkDuplicates - Mark Duplicates
- - CreateIntervals - Create Intervals
- - RealignBams - Realign Bams as T/N pair
+ - RealignerTargetCreator - Create realignment target intervals
+ - IndelRealigner - Realign BAMs as T/N pair
  - CreateRecalibrationTable - Create Recalibration Table
  - RecalibrateBam - Recalibrate Bam
  - RunSamtoolsStats - Run Samtools stats on recalibrated BAM files
@@ -260,18 +260,18 @@ duplicatesGrouped = step == 'realign' ? bamFiles.map{
 }.groupTuple(by:[0,1]) : duplicatesGrouped
 
 // The duplicatesGrouped channel is duplicated
-// one copy goes to the CreateIntervals process
-// and the other to the RealignBams process
+// one copy goes to the RealignerTargetCreator process
+// and the other to the IndelRealigner process
 (duplicatesInterval, duplicatesRealign) = duplicatesGrouped.into(2)
 
-verbose ? duplicatesInterval = duplicatesInterval.view {"BAMs for CreateIntervals: $it"} : ''
+verbose ? duplicatesInterval = duplicatesInterval.view {"BAMs for RealignerTargetCreator: $it"} : ''
 verbose ? duplicatesRealign = duplicatesRealign.view {"BAMs to phase: $it"} : ''
 verbose ? markDuplicatesReport = markDuplicatesReport.view {"MarkDuplicates report: $it"} : ''
 
 // VCF indexes are added so they will be linked, and not re-created on the fly
 //  -L "1:131941-141339" \
 
-process CreateIntervals {
+process RealignerTargetCreator {
   tag {idPatient}
 
   input:
@@ -319,10 +319,10 @@ bamsAndIntervals = duplicatesRealign
       intervals[2]
     )}
 
-verbose ? bamsAndIntervals = bamsAndIntervals.view {"Bams and Intervals phased for RealignBams: $it"} : ''
+verbose ? bamsAndIntervals = bamsAndIntervals.view {"BAMs and Intervals phased for IndelRealigner: $it"} : ''
 
 // use nWayOut to split into T/N pair again
-process RealignBams {
+process IndelRealigner {
   tag {idPatient}
 
   input:


### PR DESCRIPTION
This renames the CreateIntervals process to RealignerTargetCreator, and the RealignBams process to IndelRealigner.

I have not renamed the other processes because I find the name of the process actually clearer than the GATK names. For example, GATK BaseRecalibrator does *not* recalibrate bases, but only create the recalibration table, so CreateRecalibrationTable is appropriate IMO.