### PR TITLE
Include instead of exclude intervals to work on

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -24,7 +24,7 @@ params {
       bwaIndex    = "${genome}.{amb,ann,bwt,pac,sa}"
       genomeDict  = "$bundleDir/human_g1k_v37_decoy.dict"
       genomeIndex = "${genome}.fai"
-      intervals   = "$bundleDir/centromeres.list"
+      intervals   = "$bundleDir/wgs_calling_regions_CAW.list"
       knownIndels = [
         "$bundleDir/1000G_phase1.indels.b37.vcf",
         "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf"

--- a/doc/GENOMES.md
+++ b/doc/GENOMES.md
@@ -1,0 +1,32 @@
+# Genomes
+
+CAW currently uses GRCh37 by default. Support for GRCh38 is not fully working!
+
+
+## GRCh37
+
+...
+
+
+## GRCh38
+
+Use `--genome=GRCh38` to map against GRCh38. Before doing so and if you
+are not on Uppmax, you need to adjust the settings in `genomes.config` to your
+needs.
+
+To get the needed files, download the GATK bundle for GRCh38 from
+<ftp://gsapubftp-anonymous@ftp.broadinstitute.org/bundle/hg38/>.
+
+The MD5SUM of `Homo_sapiens_assembly38.fasta` included in that file is
+7ff134953dcca8c8997453bbb80b6b5e.
+
+From the `beta/` directory, which seems to be an older version of the bundle,
+only Homo_sapiens_assembly38.known_indels.vcf* is needed. Also, you can omit
+dbsnp_138* and dbsnp_144 files as we use dbsnp_146. The old ones also use the
+wrong chromosome naming convention.
+
+Afterwards, the following needs to be done:
+
+    gunzip Homo_sapiens_assembly38.fasta.gz
+    bwa index -6 Homo_sapiens_assembly38.fasta
+    awk '!/^@/{printf("%s:%d-%d\n", $1, $2, $3)}' wgs_calling_regions.hg38.interval_list > wgs_calling_regions.hg38.list

--- a/main.nf
+++ b/main.nf
@@ -88,7 +88,7 @@ if (!checkParameterList(tools,toolList)) {exit 1, 'Unknown tool(s), see --help f
 
 tsvPath = ''
 if (params.test) {
-  referenceMap.intervals = "$workflow.projectDir/repeats/tiny.list"
+  referenceMap.intervals = file("$workflow.projectDir/repeats/tiny.list")
   testTsvPaths = [
     'preprocessing': "$workflow.projectDir/data/tsv/tiny.tsv",
     'realign': "$workflow.launchDir/$directoryMap.nonRealigned/nonRealigned.tsv",

--- a/main.nf
+++ b/main.nf
@@ -277,12 +277,14 @@ process RealignerTargetCreator {
 
   input:
     set idPatient, gender, idSample_status, file(bam), file(bai) from duplicatesInterval
-    set file(genomeFile), file(genomeIndex), file(genomeDict), file(knownIndels), file(knownIndelsIndex) from Channel.value([
+    set file(genomeFile), file(genomeIndex), file(genomeDict), file(knownIndels), file(knownIndelsIndex), file(intervals) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
       referenceMap.genomeDict,
       referenceMap.knownIndels,
-      referenceMap.knownIndelsIndex])
+      referenceMap.knownIndelsIndex,
+      referenceMap.intervals
+    ])
 
   output:
     set idPatient, gender, file("${idPatient}.intervals") into intervals
@@ -300,8 +302,7 @@ process RealignerTargetCreator {
   -R $genomeFile \
   $known \
   -nt $task.cpus \
-  -XL hs37d5 \
-  -XL NC_007605 \
+  -L $intervals \
   -o ${idPatient}.intervals
   """
 }
@@ -351,8 +352,6 @@ process IndelRealigner {
   -R $genomeFile \
   -targetIntervals $intervals \
   $known \
-  -XL hs37d5 \
-  -XL NC_007605 \
   -nWayOut '.real.bam'
   """
 }
@@ -368,14 +367,15 @@ process CreateRecalibrationTable {
 
   input:
     set idPatient, gender, status, idSample, file(bam), file(bai) from realignedBam
-    set file(genomeFile), file(genomeIndex), file(genomeDict), file(dbsnp), file(dbsnpIndex), file(knownIndels), file(knownIndelsIndex) from Channel.value([
+    set file(genomeFile), file(genomeIndex), file(genomeDict), file(dbsnp), file(dbsnpIndex), file(knownIndels), file(knownIndelsIndex), file(intervals) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
       referenceMap.genomeDict,
       referenceMap.dbsnp,
       referenceMap.dbsnpIndex,
       referenceMap.knownIndels,
-      referenceMap.knownIndelsIndex
+      referenceMap.knownIndelsIndex,
+      referenceMap.intervals,
     ])
 
   output:
@@ -397,8 +397,7 @@ process CreateRecalibrationTable {
   -knownSites $dbsnp \
   $known \
   -nct $task.cpus \
-  -XL hs37d5 \
-  -XL NC_007605 \
+  -L $intervals \
   -l INFO \
   -o ${idSample}.recal.table
   """
@@ -422,10 +421,11 @@ process RecalibrateBam {
 
   input:
     set idPatient, gender, status, idSample, file(bam), file(bai), recalibrationReport from recalibrationTable
-    set file(genomeFile), file(genomeIndex), file(genomeDict) from Channel.value([
+    set file(genomeFile), file(genomeIndex), file(genomeDict), file(intervals) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
-      referenceMap.genomeDict
+      referenceMap.genomeDict,
+      referenceMap.intervals,
     ])
 
   output:
@@ -441,8 +441,7 @@ process RecalibrateBam {
   -T PrintReads \
   -R $genomeFile \
   -I $bam \
-  -XL hs37d5 \
-  -XL NC_007605 \
+  -L $intervals \
   --BQSR $recalibrationReport \
   -o ${idSample}.recal.bam
   """
@@ -595,8 +594,6 @@ process RunHaplotypecaller {
   -I $bam \
   -L \"$genInt\" \
   --disable_auto_index_creation_and_locking_when_reading_rods \
-  -XL hs37d5 \
-  -XL NC_007605 \
   -o ${gen_int}_${idSample}.g.vcf
   """
 }
@@ -640,8 +637,6 @@ process RunMutect1 {
   -I:tumor $bamTumor \
   -L \"$genInt\" \
   --disable_auto_index_creation_and_locking_when_reading_rods \
-  -XL hs37d5 \
-  -XL NC_007605 \
   --out ${gen_int}_${idSampleTumor}_vs_${idSampleNormal}.call_stats.out \
   --vcf ${gen_int}_${idSampleTumor}_vs_${idSampleNormal}.vcf
   """
@@ -682,8 +677,6 @@ process RunMutect2 {
   -I:tumor $bamTumor \
   --disable_auto_index_creation_and_locking_when_reading_rods \
   -L \"$genInt\" \
-  -XL hs37d5 \
-  -XL NC_007605 \
   -o ${gen_int}_${idSampleTumor}_vs_${idSampleNormal}.vcf
   """
 


### PR DESCRIPTION
Previously, nearyl all GATK tools were called with `-XL`, which is `--excludeIntervals`. It was set to `-XL hs37d5 -XL NC_007605` in order to exclude decoys and the Epstein-Barr sequence. These names are specific to GRCh37, however. With this change, we use `-L` instead, we gives a list of all intervals to *include*`. For some tools that already before got an explicit list of intervals to work on, this change just removes the `-XL` parameters as they should not have had any effect anyway.

(Need to check this: In addition, it seems that this makes `--test` runs faster because the set of intervals is restricted to a much smaller subset.)
