### PR TITLE
Use more memory for samtools sort

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -172,7 +172,7 @@ process MapReads {
   set -euo pipefail
   bwa mem -R \"$readGroup\" ${extra}-t $task.cpus -M \
   $genomeFile $fastqFile1 $fastqFile2 | \
-  samtools sort --threads $task.cpus - > ${idRun}.bam
+  samtools sort --threads $task.cpus -m 4G - > ${idRun}.bam
   """
 }
 


### PR DESCRIPTION
This reduces the number of temporary files that are created. The default is
768 MB, now it is 4 GB. Files on disk were just ca. 180 MB, which means that
hundreds of files are created for a final BAM that has perhaps 50 GB.

An even nicer solution would be to use as much memory as is available minus
about 8 GB for BWA-MEM.