### PR TITLE
Use interval list in .list format for GRCh38

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -44,7 +44,7 @@ params {
       genomeDict    = "$bundleDir/Homo_sapiens_assembly38.dict"
       genomeIndex   = "${genome}.fai"
       bwaIndex      = "${genome}.64.{amb,ann,bwt,pac,sa,alt}"
-      intervals     = "$bundleDir/wgs_calling_regions.hg38.interval_list"  // TODO different format
+      intervals     = "$bundleDir/wgs_calling_regions.hg38.list"
       knownIndels   = [
         "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
         "$bundleDir/beta/Homo_sapiens_assembly38.known_indels.vcf.gz"


### PR DESCRIPTION
Parsing the file will fail otherwise.

GATK supports multiple formats (also the .interval_list format), but since
we parse the interval list ourselves, it’s easier to work with the .list
format for both genome versions (GRCh37 and GRCh38).

How to convert .interval_list to .list is documented in GENOMES.md