### PR TITLE
Move bundleDir into genomes.config

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -14,6 +14,7 @@ vim: syntax=groovy
 params {
   genomes {
     'GRCh37' {
+      bundleDir   = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37'
       acLoci      = "$bundleDir/1000G_phase3_20130502_SNP_maf0.3.loci"
       cosmic      = "$bundleDir/b37_cosmic_v74.noCHR.sort.4.1.vcf"
       cosmicIndex = "${cosmic}.idx"
@@ -35,6 +36,7 @@ params {
       snpeffDb    = "GRCh37.75"
     }
     'GRCh38' {
+      bundleDir     = '/sw/data/uppnex/ToolBox/hg38bundle'
       acLoci        = "/dev/null"
       cosmic        = "/dev/null"
       cosmicIndex   = "/dev/null" //"${cosmic}.idx"

--- a/configuration/uppmax.config
+++ b/configuration/uppmax.config
@@ -18,11 +18,9 @@ params {
   genome = 'GRCh37'
   genomes {
     'GRCh37' {
-      bundleDir     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37'
       vardictHome   = "/sw/apps/bioinfo/VarDictJava/1.4.5/milou/VarDictJava/"
     }
     'GRCh38' {
-      bundleDir     = '/sw/data/uppnex/ToolBox/hg38bundle'
       vardictHome   = "/dev/null"
     }
   }


### PR DESCRIPTION
When adding a new genome, one currently needs to edit both uppmax.config
and genomes.config. With bundleDir also in genomes.config, only one file
needs to be customized.

Closes #270