### PR TITLE
Remove unused -stand_call_conf option to HaplotypeCaller

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -586,7 +586,9 @@ process RunHaplotypecaller {
   java -Xmx${task.memory.toGiga()}g \
   -jar \$GATK_HOME/GenomeAnalysisTK.jar \
   -T HaplotypeCaller \
-  --emitRefConfidence GVCF -stand_call_conf 30.0  -pairHMM LOGLESS_CACHING  -pcrModel CONSERVATIVE \
+  --emitRefConfidence GVCF \
+  -pairHMM LOGLESS_CACHING \
+  -pcrModel CONSERVATIVE \
   -R $genomeFile \
   --dbsnp $dbsnp \
   -I $bam \


### PR DESCRIPTION
According to
https://software.broadinstitute.org/gatk/documentation/tooldocs/current/org_broadinstitute_gatk_tools_walkers_haplotypecaller_HaplotypeCaller.php
the option is set to 0 anyway when --emitRefConfidence GVCF is used:

> When running in `-ERC GVCF` or `-ERC BP_RESOLUTION` modes, the
> emitting and calling confidence thresholds are automatically set
> to 0. This cannot be overridden by the command line.