### PR TITLE
VarDictJava clean up

### DIFF
--- a/configuration/docker.config
+++ b/configuration/docker.config
@@ -19,11 +19,6 @@ env {
 
 params {
   genome = 'smallGRCh37'
-  genomes {
-    'smallGRCh37' {
-      vardictHome = "/dev/null"
-    }
-  }
 }
 
 process {
@@ -52,6 +47,6 @@ process {
   $RunSamtoolsStats.container         = 'maxulysse/samtools:1.1'
   $RunSnpeff.container                = 'maxulysse/snpeffgrch37:1.1'
   $RunStrelka.container               = 'maxulysse/strelka:1.1'
-  $RunVardict.container               = 'maxulysse/vardict:1.1'
+  $RunVardict.container               = 'maxulysse/vardictjava:1.1'
   $RunVEP.container                   = 'maxulysse/vepgrch37:1.1'
 }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -24,11 +24,9 @@ params {
   genomes {
     'GRCh37' {
       bundleDir     = '/sw/data/uppnex/ToolBox/ReferenceAssemblies/hg38make/bundle/2.8/b37'
-      vardictHome   = "/sw/apps/bioinfo/VarDictJava/1.4.5/milou/VarDictJava/"
     }
     'GRCh38' {
       bundleDir     = '/sw/data/uppnex/ToolBox/hg38bundle'
-      vardictHome   = "/dev/null"
     }
   }
 }

--- a/configuration/uppmax.config
+++ b/configuration/uppmax.config
@@ -16,14 +16,6 @@ env {
 
 params {
   genome = 'GRCh37'
-  genomes {
-    'GRCh37' {
-      vardictHome   = "/sw/apps/bioinfo/VarDictJava/1.4.5/milou/VarDictJava/"
-    }
-    'GRCh38' {
-      vardictHome   = "/dev/null"
-    }
-  }
 }
 
 process {

--- a/main.nf
+++ b/main.nf
@@ -737,7 +737,7 @@ process RunVardict {
 
   script:
   """
-  ${referenceMap.vardictHome}/vardict.pl \
+  vardict.pl \
   -G $genomeFile \
   -f 0.01 -N $bamTumor \
   -b "$bamTumor|$bamNormal" \
@@ -782,11 +782,12 @@ process ConcatVCF {
     """
     set -euo pipefail
     for i in $vcFiles ;do
-      cat \$i | ${referenceMap.vardictHome}/VarDict/testsomatic.R >> testsomatic.out
+      cat \$i | testsomatic.R >> testsomatic.out
     done
-    ${referenceMap.vardictHome}/VarDict/var2vcf_somatic.pl \
+    var2vcf_paired.pl \
     -f 0.01 \
     -N "${idSampleTumor}_vs_${idSampleNormal}" testsomatic.out > $outputFile
+    gzip -v $outputFile
     """
 
   else if (variantCaller == 'mutect2' || variantCaller == 'mutect1' || variantCaller == 'haplotypecaller' || variantCaller == 'freebayes')
@@ -1379,7 +1380,6 @@ def defineReferenceMap() {
     'bwaIndex'    : file(genome.bwaIndex),  // BWA index files
     // intervals file for spread-and-gather processes (usually chromosome chunks at centromeres)
     'intervals'   : file(genome.intervals),
-    'vardictHome' : file(genome.vardictHome),  // path to VarDict
     // VCFs with known indels (such as 1000 Genomes, Mill’s gold standard)
     'knownIndels' : genome.knownIndels.collect{file(it)},
     'knownIndelsIndex': genome.knownIndelsIndex.collect{file(it)},

--- a/test/test_docker.sh
+++ b/test/test_docker.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 echo "Starting Nextflow... Command:"
-echo "./nextflow run buildReferences.nf -profile testing --storeDirectory smallGRCh37"
+echo "./nextflow run buildReferences.nf -profile testing"
 echo "-----"
-./nextflow run buildReferences.nf -profile testing --storeDirectory smallGRCh37
+./nextflow run buildReferences.nf -profile testing
 echo "Cleaning up docker images:"
 echo "docker rmi -f maxulysse/igvtools:1.1"
 echo "-----"

--- a/test/test_docker.sh
+++ b/test/test_docker.sh
@@ -24,6 +24,6 @@ echo "./nextflow run . -profile testing --test --step recalibrate"
 echo "-----"
 ./nextflow run . -profile testing --test --step recalibrate
 echo "Starting Nextflow... Command:"
-echo "./nextflow run . -profile testing --test --step skipPreprocessing --tools HaplotypeCaller,MultiQC,MuTect1,MuTect2,Strelka,snpEff,VEP"
+echo "./nextflow run . -profile testing --test --step skipPreprocessing --tools HaplotypeCaller,MultiQC,MuTect1,MuTect2,Strelka,snpEff,VEP,VarDict"
 echo "-----"
-./nextflow run . -profile testing --test --step skipPreprocessing --tools HaplotypeCaller,MultiQC,MuTect1,MuTect2,Strelka,snpEff,VEP
+./nextflow run . -profile testing --test --step skipPreprocessing --tools HaplotypeCaller,MultiQC,MuTect1,MuTect2,Strelka,snpEff,VEP,VarDict


### PR DESCRIPTION
Removed VarDictHome.
UPPMAX use PATH wrapper for directory inside the VarDictJava installation.
And they also installed VarDict inside the VarDictJava installation (which is also wrapped inside PATH).
So cleaned the path to the scripts inside this directory

Inside the ConcatVCF process:
Change the use of `var2vcf_somatic.pl` to `var2vcf_paired.pl` as it is deprecated cf https://github.com/AstraZeneca-NGS/VarDict/issues/46
and gzip the final file

close #271 