### PR TITLE
Add path to COSMIC GRCh38 VCF

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -38,8 +38,8 @@ params {
     'GRCh38' {
       bundleDir     = '/sw/data/uppnex/ToolBox/hg38bundle'
       acLoci        = "/dev/null"
-      cosmic        = "/dev/null"
-      cosmicIndex   = "/dev/null" //"${cosmic}.idx"
+      cosmic        = "${bundleDir}/COSMICv80.vcf.gz"
+      cosmicIndex   = "${cosmic}.idx"
       dbsnp         = "$bundleDir/dbsnp_146.hg38.vcf.gz"
       dbsnpIndex    = "${dbsnp}.tbi"
       genome        = "$bundleDir/Homo_sapiens_assembly38.fasta"


### PR DESCRIPTION
I haven’t tested this since I’m not using Cosmic, but the path should be fine.

The file has been generated by @Sebastian-D 