### PR TITLE
 Enable set -euo pipefail by default for all shells

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -3,6 +3,7 @@
 /*
 vim: syntax=groovy
 -*- mode: groovy;-*-
+kate: syntax groovy; space-indent on; indent-width 4;
 ================================================================================
 =               C A N C E R    A N A L Y S I S    W O R K F L O W              =
 ================================================================================

--- a/main.nf
+++ b/main.nf
@@ -173,7 +173,6 @@ process MapReads {
   // adjust mismatch penalty for tumor samples
   extra = status == 1 ? "-B 3 " : ""
   """
-  set -euo pipefail
   bwa mem -R \"$readGroup\" ${extra}-t $task.cpus -M \
   $genomeFile $fastqFile1 $fastqFile2 | \
   samtools sort --threads $task.cpus -m 4G - > ${idRun}.bam
@@ -781,7 +780,6 @@ process ConcatVCF {
 
   if (variantCaller == 'vardict')
     """
-    set -euo pipefail
     for i in $vcFiles ;do
       cat \$i | ${referenceMap.vardictHome}/VarDict/testsomatic.R >> testsomatic.out
     done
@@ -792,7 +790,6 @@ process ConcatVCF {
 
   else if (variantCaller == 'mutect2' || variantCaller == 'mutect1' || variantCaller == 'haplotypecaller' || variantCaller == 'freebayes')
     """
-    set -euo pipefail
     # first make a header from one of the VCF intervals
     # get rid of interval information only from the GATK command-line, but leave the rest
     awk '/^#/{print}' `ls *vcf| head -1` | \
@@ -833,7 +830,6 @@ process RunStrelka {
 
   script:
   """
-  set -euo pipefail
   tumorPath=`readlink $bamTumor`
   normalPath=`readlink $bamNormal`
   genomeFile=`readlink $genomeFile`
@@ -878,7 +874,6 @@ process RunManta {
 
   script:
   """
-  set -eo pipefail
   ln -s $bamNormal Normal.bam
   ln -s $bamTumor Tumor.bam
   ln -s $baiNormal Normal.bam.bai
@@ -1113,7 +1108,6 @@ process RunSnpeff {
 
   script:
   """
-  set -euo pipefail
   java -Xmx${task.memory.toGiga()}g \
   -jar \$SNPEFF_HOME/snpEff.jar \
   $snpeffDb \
@@ -1143,7 +1137,6 @@ process RunVEP {
 
   script:
   """
-  set -euo pipefail
   vep -i $vcf -o ${vcf.baseName}_VEP.txt -offline
 
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -56,6 +56,8 @@ profiles {
   }
 }
 
+process.shell = ['/bin/bash', '-euo', 'pipefail']
+
 // Turning on timeline tracking by default
 timeline {
   enabled = true


### PR DESCRIPTION
`set -eu` is already enabled by Nextflow, but `-o pipefail` is missing.
See discussion at nextflow-io/nextflow#151