### PR TITLE
Change in Ascat

### DIFF
--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -39,4 +39,4 @@ ascat.plotSegmentedData(ascat.bc)
 ascat.output <- ascat.runAscat(ascat.bc)
 
 #Write out segmented regions
-write.table(ascat.output$segments, file=paste(tumorname, "tumor.segments.txt", sep=""), sep="\t", quote=F, row.names=F)
+write.table(ascat.output$segments, file=paste(tumorname, ".segments.txt", sep=""), sep="\t", quote=F, row.names=F)

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -41,7 +41,7 @@ ascat.output <- ascat.runAscat(ascat.bc)
 
 #Write out CNVs in bed format
 cnvs=ascat.output$segments[ascat.output$segments[,"nMajor"]!=1 | ascat.output$segments[,"nMinor"]!=1,2:6]
-write.table(cnvs, file=paste(samplename,".cnvs.bed",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
+write.table(cnvs, file=paste(samplename,".cnvs.txt",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
 
 #Write out purity and ploidy info
 summary <- matrix(c(ascat.output$aberrantcellfraction, ascat.output$ploidy), ncol=2, byrow=TRUE)

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -1,0 +1,41 @@
+#!/bin/env Rscript
+source("$baseDir/scripts/ascat.R")
+args = commandArgs(trailingOnly=TRUE)
+.libPaths( c( "$baseDir/scripts", .libPaths() ) )
+if(!require(RColorBrewer)){
+    source("http://bioconductor.org/biocLite.R")
+    biocLite("RColorBrewer", suppressUpdates=TRUE, lib="$baseDir/scripts")
+    library(RColorBrewer)
+}
+options(bitmapType='cairo')
+
+
+##args is now a list of character vectors
+## First check to see if arguments are passed.
+if(length(args)<5){
+    stop("No input files supplied\n\nUsage:\nRscript run_ascat.r tumor_baf tumor_logr normal_baf normal_logr tumor_sample_name\n\n")
+} else{
+    tumorbaf = args[1]
+    tumorlogr = args[2]
+    normalbaf = args[3]
+    normallogr = args[4]
+    tumorname = args[5]
+}
+
+#Load the  data
+ascat.bc <- ascat.loadData(Tumor_LogR_file=tumorlogr, Tumor_BAF_file=tumorbaf, Germline_LogR_file=normallogr, Germline_BAF_file=normalbaf)
+
+#Plot the raw data
+ascat.plotRawData(ascat.bc)
+
+#Segment the data
+ascat.bc <- ascat.aspcf(ascat.bc)
+
+#Plot the segmented data
+ascat.plotSegmentedData(ascat.bc)
+
+#Run ASCAT to fit every tumor to a model, inferring ploidy, normal cell contamination, and discrete copy numbers
+ascat.output <- ascat.runAscat(ascat.bc)
+
+#Write out segmented regions
+write.table(ascat.output$segments, file=paste(tumorname, "tumor.segments.txt", sep=""), sep="\t", quote=F, row.names=F)

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -41,7 +41,7 @@ ascat.output <- ascat.runAscat(ascat.bc)
 
 #Write out CNVs in bed format
 cnvs=ascat.output$segments[ascat.output$segments[,"nMajor"]!=1 | ascat.output$segments[,"nMinor"]!=1,2:6]
-write.table(cnvs, file=paste(samplename,".cnvs.bed",sep=""), sep="\t", quote=F, row.names=F, col.names=F)
+write.table(cnvs, file=paste(samplename,".cnvs.bed",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
 
 #Write out purity and ploidy info
 summary <- matrix(c(ascat.output$aberrantcellfraction, ascat.output$ploidy), ncol=2, byrow=TRUE)

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -41,7 +41,7 @@ ascat.output <- ascat.runAscat(ascat.bc)
 
 #Write out CNVs in bed format
 cnvs=ascat.output$segments[ascat.output$segments[,"nMajor"]!=1 | ascat.output$segments[,"nMinor"]!=1,2:6]
-write.table(cnvs, file=paste(samplename,".cnvs.txt",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
+write.table(cnvs, file=paste(tumorname,".cnvs.txt",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
 
 #Write out purity and ploidy info
 summary <- matrix(c(ascat.output$aberrantcellfraction, ascat.output$ploidy), ncol=2, byrow=TRUE)

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -36,8 +36,12 @@ ascat.plotSegmentedData(ascat.bc)
 #Run ASCAT to fit every tumor to a model, inferring ploidy, normal cell contamination, and discrete copy numbers
 ascat.output <- ascat.runAscat(ascat.bc)
 
-#Write out segmented regions
-write.table(ascat.output$segments, file=paste(tumorname, ".segments.txt", sep=""), sep="\t", quote=F, row.names=F)
+#Write out segmented regions (including regions with one copy of each allele)
+#write.table(ascat.output$segments, file=paste(tumorname, ".segments.txt", sep=""), sep="\t", quote=F, row.names=F)
+
+#Write out CNVs in bed format
+cnvs=ascat.output$segments[ascat.output$segments[,"nMajor"]!=1 | ascat.output$segments[,"nMinor"]!=1,2:6]
+write.table(cnvs, file=paste(samplename,".cnvs.bed",sep=""), sep="\t", quote=F, row.names=F, col.names=F)
 
 #Write out purity and ploidy info
 summary <- matrix(c(ascat.output$aberrantcellfraction, ascat.output$ploidy), ncol=2, byrow=TRUE)

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -12,7 +12,6 @@ if(length(args)<6){
 
 }
 
-#.libPaths((paste(baseDir,"/scripts", sep="") .libPaths()))
 source(paste(baseDir,"/scripts/ascat.R", sep=""))
 
 if(!require(RColorBrewer)){
@@ -21,7 +20,6 @@ if(!require(RColorBrewer)){
     library(RColorBrewer)
 }
 options(bitmapType='cairo')
-
 
 #Load the  data
 ascat.bc <- ascat.loadData(Tumor_LogR_file=tumorlogr, Tumor_BAF_file=tumorbaf, Germline_LogR_file=normallogr, Germline_BAF_file=normalbaf)
@@ -40,3 +38,10 @@ ascat.output <- ascat.runAscat(ascat.bc)
 
 #Write out segmented regions
 write.table(ascat.output$segments, file=paste(tumorname, ".segments.txt", sep=""), sep="\t", quote=F, row.names=F)
+
+#Write out purity and ploidy info
+summary <- matrix(c(ascat.output$aberrantcellfraction, ascat.output$ploidy), ncol=2, byrow=TRUE)
+colnames(summary) <- c("AberrantCellFraction","Ploidy")
+write.table(summary, file=paste(tumorname,".PurityPloidy.txt",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
+
+

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -12,7 +12,7 @@ if(length(args)<6){
 
 }
 
-.libPaths( ( paste(baseDir,"/scripts", sep=""), .libPaths() ) )
+.libPaths((paste(baseDir,"/scripts", sep="") .libPaths()))
 source(paste(baseDir,"/scripts/ascat.R", sep=""))
 
 if(!require(RColorBrewer)){

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -12,7 +12,7 @@ if(length(args)<6){
 
 }
 
-.libPaths((paste(baseDir,"/scripts", sep="") .libPaths()))
+#.libPaths((paste(baseDir,"/scripts", sep="") .libPaths()))
 source(paste(baseDir,"/scripts/ascat.R", sep=""))
 
 if(!require(RColorBrewer)){

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -42,6 +42,6 @@ write.table(ascat.output$segments, file=paste(tumorname, ".segments.txt", sep=""
 #Write out purity and ploidy info
 summary <- matrix(c(ascat.output$aberrantcellfraction, ascat.output$ploidy), ncol=2, byrow=TRUE)
 colnames(summary) <- c("AberrantCellFraction","Ploidy")
-write.table(summary, file=paste(tumorname,".PurityPloidy.txt",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
+write.table(summary, file=paste(tumorname,".purityploidy.txt",sep=""), sep="\t", quote=F, row.names=F, col.names=T)
 
 

--- a/bin/run_ascat.r
+++ b/bin/run_ascat.r
@@ -1,7 +1,20 @@
 #!/bin/env Rscript
-source("$baseDir/scripts/ascat.R")
 args = commandArgs(trailingOnly=TRUE)
-.libPaths( c( "$baseDir/scripts", .libPaths() ) )
+if(length(args)<6){
+    stop("No input files supplied\n\nUsage:\nRscript run_ascat.r tumor_baf tumor_logr normal_baf normal_logr tumor_sample_name baseDir\n\n")
+} else{
+    tumorbaf = args[1]
+    tumorlogr = args[2]
+    normalbaf = args[3]
+    normallogr = args[4]
+    tumorname = args[5]
+    baseDir = args[6]
+
+}
+
+.libPaths( ( paste(baseDir,"/scripts", sep=""), .libPaths() ) )
+source(paste(baseDir,"/scripts/ascat.R", sep=""))
+
 if(!require(RColorBrewer)){
     source("http://bioconductor.org/biocLite.R")
     biocLite("RColorBrewer", suppressUpdates=TRUE, lib="$baseDir/scripts")
@@ -9,18 +22,6 @@ if(!require(RColorBrewer)){
 }
 options(bitmapType='cairo')
 
-
-##args is now a list of character vectors
-## First check to see if arguments are passed.
-if(length(args)<5){
-    stop("No input files supplied\n\nUsage:\nRscript run_ascat.r tumor_baf tumor_logr normal_baf normal_logr tumor_sample_name\n\n")
-} else{
-    tumorbaf = args[1]
-    tumorlogr = args[2]
-    normalbaf = args[3]
-    normallogr = args[4]
-    tumorname = args[5]
-}
 
 #Load the  data
 ascat.bc <- ascat.loadData(Tumor_LogR_file=tumorlogr, Tumor_BAF_file=tumorbaf, Germline_LogR_file=normallogr, Germline_BAF_file=normalbaf)

--- a/main.nf
+++ b/main.nf
@@ -974,7 +974,7 @@ process RunAscat {
 
   script:
   """
-  run_ascat.r $bafTumor $logrTumor $bafNormal $logrNormal $idSampleTumor
+  run_ascat.r $bafTumor $logrTumor $bafNormal $logrNormal $idSampleTumor $baseDir
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -1011,6 +1011,10 @@ process RunAscat {
   ascat.plotSegmentedData(ascat.bc)
   #Run ASCAT to fit every tumor to a model, inferring ploidy, normal cell contamination, and discrete copy numbers
   ascat.output <- ascat.runAscat(ascat.bc)
+  write.table(ascat.output$segments, file="tumor.segments.txt", sep="\t", quote=F, row.names=F)
+  write.table(ascat.output$aberrantcellfraction, file="tumor.acf.txt", sep="\t", quote=F, row.names=F)
+  write.table(ascat.output$ploidy, file="tumor.ploidy.txt", sep="\t", quote=F, row.names=F)
+
   #str(ascat.output)
   #plot(sort(ascat.output\$aberrantcellfraction))
   #plot(density(ascat.output\$ploidy))

--- a/main.nf
+++ b/main.nf
@@ -968,7 +968,7 @@ process RunAscat {
     set idPatient, gender, idSampleNormal, idSampleTumor, file(bafNormal), file(logrNormal), file(bafTumor), file(logrTumor) from convertAlleleCountsOutput
 
   output:
-    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png"), file("${idSampleTumor}.cnvs.bed"),file("${idSampleTumor}.purityploidy.txt") into ascatOutput
+    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png"), file("${idSampleTumor}.cnvs.txt"),file("${idSampleTumor}.purityploidy.txt") into ascatOutput
 
   when: 'Ascat' in tools
 

--- a/main.nf
+++ b/main.nf
@@ -968,7 +968,7 @@ process RunAscat {
     set idPatient, gender, idSampleNormal, idSampleTumor, file(bafNormal), file(logrNormal), file(bafTumor), file(logrTumor) from convertAlleleCountsOutput
 
   output:
-    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png"), file("${idSampleTumor}.segments.txt") into ascatOutput
+    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png"), file("${idSampleTumor}.segments.txt"),file("${idSampleTumor}.purityploidy.txt") into ascatOutput
 
   when: 'Ascat' in tools
 

--- a/main.nf
+++ b/main.nf
@@ -968,7 +968,7 @@ process RunAscat {
     set idPatient, gender, idSampleNormal, idSampleTumor, file(bafNormal), file(logrNormal), file(bafTumor), file(logrTumor) from convertAlleleCountsOutput
 
   output:
-    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png, file("${idSampleTumor}.segments.txt") into ascatOutput
+    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png), file("${idSampleTumor}.segments.txt") into ascatOutput
 
   when: 'Ascat' in tools
 

--- a/main.nf
+++ b/main.nf
@@ -974,45 +974,7 @@ process RunAscat {
 
   script:
   """
-  #!/bin/env Rscript
-  ##############################################################################
-  # Description:                                                               #
-  # R-script for converting output from AlleleCount to BAF and LogR values.    #
-  #                                                                            #
-  # Input:                                                                     #
-  # AlleleCounter output file for tumor and normal samples                     #
-  # The first line should contain a header describing the data                 #
-  # The following columns and headers should be present:                       #
-  # CHR    POS     Count_A Count_C Count_G Count_T Good_depth                  #
-  #                                                                            #
-  # Output:                                                                    #
-  # BAF and LogR tables (tab delimited text files)                             #
-  ##############################################################################
-  source("$baseDir/scripts/ascat.R")
-  .libPaths( c( "$baseDir/scripts", .libPaths() ) )
-  if(!require(RColorBrewer)){
-      source("http://bioconductor.org/biocLite.R")
-      biocLite("RColorBrewer", suppressUpdates=TRUE, lib="$baseDir/scripts")
-      library(RColorBrewer)
-  }
-
-  options(bitmapType='cairo')
-  tumorbaf = "$bafTumor"
-  tumorlogr = "$logrTumor"
-  normalbaf = "$bafNormal"
-  normallogr = "$logrNormal"
-  tumorsample = "$idSampleTumor"
-  #Load the  data
-  ascat.bc <- ascat.loadData(Tumor_LogR_file=tumorlogr, Tumor_BAF_file=tumorbaf, Germline_LogR_file=normallogr, Germline_BAF_file=normalbaf)
-  #Plot the raw data
-  ascat.plotRawData(ascat.bc)
-  #Segment the data
-  ascat.bc <- ascat.aspcf(ascat.bc)
-  #Plot the segmented data
-  ascat.plotSegmentedData(ascat.bc)
-  #Run ASCAT to fit every tumor to a model, inferring ploidy, normal cell contamination, and discrete copy numbers
-  ascat.output <- ascat.runAscat(ascat.bc)
-  write.table(ascat.output$segments, file=paste(tumorsample,".segments.txt",sep=""), sep="\t", quote=F, row.names=F)
+  run_ascat.r $bafTumor $logrTumor $bafNormal $logrNormal $idSampleTumor
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -1001,7 +1001,7 @@ process RunAscat {
   tumorlogr = "$logrTumor"
   normalbaf = "$bafNormal"
   normallogr = "$logrNormal"
-  tsf = "${idSampleTumor}.segments.txt"
+  tumorsample = "$idSampleTumor"
   #Load the  data
   ascat.bc <- ascat.loadData(Tumor_LogR_file=tumorlogr, Tumor_BAF_file=tumorbaf, Germline_LogR_file=normallogr, Germline_BAF_file=normalbaf)
   #Plot the raw data
@@ -1012,7 +1012,7 @@ process RunAscat {
   ascat.plotSegmentedData(ascat.bc)
   #Run ASCAT to fit every tumor to a model, inferring ploidy, normal cell contamination, and discrete copy numbers
   ascat.output <- ascat.runAscat(ascat.bc)
-  write.table(ascat.output$segments, file=tsf, sep="\t", quote=F, row.names=F)
+  write.table(ascat.output$segments, file=paste(tumorsample,".segments.txt",sep=""), sep="\t", quote=F, row.names=F)
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -968,7 +968,7 @@ process RunAscat {
     set idPatient, gender, idSampleNormal, idSampleTumor, file(bafNormal), file(logrNormal), file(bafTumor), file(logrTumor) from convertAlleleCountsOutput
 
   output:
-    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png), file("${idSampleTumor}.segments.txt") into ascatOutput
+    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png"), file("${idSampleTumor}.segments.txt") into ascatOutput
 
   when: 'Ascat' in tools
 

--- a/main.nf
+++ b/main.nf
@@ -968,7 +968,7 @@ process RunAscat {
     set idPatient, gender, idSampleNormal, idSampleTumor, file(bafNormal), file(logrNormal), file(bafTumor), file(logrTumor) from convertAlleleCountsOutput
 
   output:
-    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png") into ascatOutput
+    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png, file("${idSampleTumor}.segments.txt") into ascatOutput
 
   when: 'Ascat' in tools
 
@@ -1001,6 +1001,7 @@ process RunAscat {
   tumorlogr = "$logrTumor"
   normalbaf = "$bafNormal"
   normallogr = "$logrNormal"
+  tsf = "${idSampleTumor}.segments.txt"
   #Load the  data
   ascat.bc <- ascat.loadData(Tumor_LogR_file=tumorlogr, Tumor_BAF_file=tumorbaf, Germline_LogR_file=normallogr, Germline_BAF_file=normalbaf)
   #Plot the raw data
@@ -1011,13 +1012,7 @@ process RunAscat {
   ascat.plotSegmentedData(ascat.bc)
   #Run ASCAT to fit every tumor to a model, inferring ploidy, normal cell contamination, and discrete copy numbers
   ascat.output <- ascat.runAscat(ascat.bc)
-  write.table(ascat.output$segments, file="tumor.segments.txt", sep="\t", quote=F, row.names=F)
-  write.table(ascat.output$aberrantcellfraction, file="tumor.acf.txt", sep="\t", quote=F, row.names=F)
-  write.table(ascat.output$ploidy, file="tumor.ploidy.txt", sep="\t", quote=F, row.names=F)
-
-  #str(ascat.output)
-  #plot(sort(ascat.output\$aberrantcellfraction))
-  #plot(density(ascat.output\$ploidy))
+  write.table(ascat.output$segments, file=tsf, sep="\t", quote=F, row.names=F)
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -968,7 +968,7 @@ process RunAscat {
     set idPatient, gender, idSampleNormal, idSampleTumor, file(bafNormal), file(logrNormal), file(bafTumor), file(logrTumor) from convertAlleleCountsOutput
 
   output:
-    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png"), file("${idSampleTumor}.segments.txt"),file("${idSampleTumor}.purityploidy.txt") into ascatOutput
+    set val("ascat"), idPatient, gender, idSampleNormal, idSampleTumor, file("${idSampleTumor}.tumour.png"), file("${idSampleTumor}.germline.png"), file("${idSampleTumor}.LogR.PCFed.txt"), file("${idSampleTumor}.BAF.PCFed.txt"), file("${idSampleTumor}.ASPCF.png"), file("${idSampleTumor}.ASCATprofile.png"), file("${idSampleTumor}.aberrationreliability.png"), file("${idSampleTumor}.rawprofile.png"), file("${idSampleTumor}.sunrise.png"), file("${idSampleTumor}.cnvs.bed"),file("${idSampleTumor}.purityploidy.txt") into ascatOutput
 
   when: 'Ascat' in tools
 


### PR DESCRIPTION
1) I moved the R code in process "RunAscat" to a separate script in CAW/bin/run_ascat.r
This script is called in main.nf exactly like in process "RunConvertAlleleCounts".

2) Ascat now creates an additional file with the actual CNV regions. This file is created in the R-code in CAW/bin/run_ascat.r
The output file is called idSampleTumor.cnvs.txt and has the following format:
chr     startpos        endpos  nMajor  nMinor
1       30863705        30867104        4       3
1       56128724        56133074        9       6
2       79748960        81240737        2       1

where the columns contain
1) Chromosome
2) start position of CNV region
2) end position of CNV region
4) Number of copies of "major allele" for this region (major and minor alleles are arbitrary)
5) Number of copies of "minor allele" for this region 

So for the example CNV at chromosome 1 basepair 30863705 to 30867104 Ascat reports 4 copies of one of the chromosomes and 3 copies of the other chromosome.
