### PR TITLE
 Add a RunGenotypeGVCFs process

### DIFF
--- a/configuration/docker.config
+++ b/configuration/docker.config
@@ -37,6 +37,7 @@ process {
   $RunFastQC.container                = 'maxulysse/fastqc:1.1'
   $RunFreeBayes.container             = 'maxulysse/freebayes:1.1'
   $RunHaplotypecaller.container       = 'maxulysse/gatk:1.1'
+  $RunGenotypeGVCFs.container         = 'maxulysse/gatk:1.1'
   $RunManta.container                 = 'maxulysse/runmanta:1.1'
   $RunMultiQC.container               = 'maxulysse/multiqc:1.1'
   $RunMutect1.container               = 'maxulysse/mutect1:1.1'

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -24,12 +24,12 @@ params {
 }
 
 process {
-  cpus = 16 			// this is the default for example when a multithreaded process uses all the available CPUs
+  cpus = 16  // this is the default for example when a multithreaded process uses all the available CPUs
   errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
   maxErrors = '-1'
-  maxForks = 2		// number of processess launched. If your process is using only a single CPU, and not that much memory, you can increase this value
+  maxForks = 2  // number of processess launched. If your process is using only a single CPU, and not that much memory, you can increase this value
   maxRetries = 3
-  memory = 240.GB	// default assigned memory value for a single process
+  memory = 240.GB  // default assigned memory value for a single process
 
   $BuildBWAindexes {
     module = ['bioinfo-tools', 'bwa/0.7.15', 'samtools/1.3']
@@ -112,7 +112,7 @@ process {
     module = ['bioinfo-tools', 'java/sun_jdk1.8.0_92', 'GATK/3.7']
     cpus = 1
     memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
-    maxForks = 16	// if you are running out of memory on a single node, due to task re-runs, decrease this value
+    maxForks = 16  // if you are running out of memory on a single node, due to task re-runs, decrease this value
   }
   $RunManta {
     module = ['bioinfo-tools', 'samtools/1.3', 'manta/1.0.3']

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -114,6 +114,11 @@ process {
     memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
     maxForks = 16  // if you are running out of memory on a single node, due to task re-runs, decrease this value
   }
+  $RunGenotypeGVCFs {
+    module = ['bioinfo-tools', 'java/sun_jdk1.8.0_92', 'GATK/3.7']
+    cpus = 1
+    memory = {params.singleCPUMem}
+  }
   $RunManta {
     module = ['bioinfo-tools', 'samtools/1.3', 'manta/1.0.3']
   }

--- a/configuration/uppmax.config
+++ b/configuration/uppmax.config
@@ -111,6 +111,11 @@ process {
     cpus = 1
     memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
   }
+  $RunGenotypeGVCFs {
+    module = ['bioinfo-tools', 'java/sun_jdk1.8.0_92', 'GATK/3.7']
+    cpus = 1
+    memory = {params.singleCPUMem}
+  }
   $RunManta {
     module = ['bioinfo-tools', 'samtools/1.3', 'manta/1.0.3']
   }

--- a/main.nf
+++ b/main.nf
@@ -787,7 +787,7 @@ process ConcatVCF {
     gzip -v $outputFile
     """
 
-  else if (variantCaller == 'mutect2' || variantCaller == 'mutect1' || variantCaller == 'gvcf-hc' || variantCaller == 'freebayes')
+  else if (variantCaller in ['mutect1', 'mutect2', 'gvcf-hc', 'freebayes'])
     """
     # first make a header from one of the VCF intervals
     # get rid of interval information only from the GATK command-line, but leave the rest

--- a/main.nf
+++ b/main.nf
@@ -3,7 +3,7 @@
 /*
 vim: syntax=groovy
 -*- mode: groovy;-*-
-kate: syntax groovy; space-indent on; indent-width 4;
+kate: syntax groovy; space-indent on; indent-width 2;
 ================================================================================
 =               C A N C E R    A N A L Y S I S    W O R K F L O W              =
 ================================================================================

--- a/main.nf
+++ b/main.nf
@@ -582,7 +582,7 @@ process RunHaplotypecaller {
     ])
 
   output:
-    set val("gvcf-hc"), idPatient, gender, idSample, val("${gen_int}_${idSample}"), file("${gen_int}_${idSample}.g.vcf") into hcGenomicVCF
+    set val("gvcf-hc"), idPatient, gender, idSample, idSample, val("${gen_int}_${idSample}"), file("${gen_int}_${idSample}.g.vcf") into hcGenomicVCF
 
   when: 'haplotypecaller' in tools
 
@@ -602,11 +602,7 @@ process RunHaplotypecaller {
   """
 }
 
-hcGenomicVCF = hcGenomicVCF.map {
-  variantCaller, idPatient, gender, idSample, tag, vcfFile ->
-  [variantCaller, idPatient, gender, idSample, idSample, tag, vcfFile]
-}.groupTuple(by:[0,1,2,3,4])
-
+hcGenomicVCF = hcGenomicVCF.groupTuple(by:[0,1,2,3,4])
 verbose ? hcGenomicVCF = hcGenomicVCF.view {"HaplotypeCaller output: $it"} : ''
 
 process RunMutect1 {


### PR DESCRIPTION
The process gets HaplotypeCaller’s genomic VCFs (.g.vcf) files as
input and converts them to regular VCFs. This is done on the interval-split
VCF files. Both the normal and the genomic VCF are then passed to ConcatVCF
in order to create whole-genome VCFs. The output is written to
VariantCalling/HaplotypeCaller.

This makes makes the pipeline a bit slower, and I have not tested by how much. However, I hope that I can improve ConcatVCF speed (see #305), and then we are hopefully back to the original runtime.

Feel free to wait with merging until I have run this on a full dataset.