### PR TITLE
Sort intervals of calling regions by processing time

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -46,7 +46,7 @@ params {
       genomeDict    = "$bundleDir/Homo_sapiens_assembly38.dict"
       genomeIndex   = "${genome}.fai"
       bwaIndex      = "${genome}.64.{amb,ann,bwt,pac,sa,alt}"
-      intervals     = "$bundleDir/wgs_calling_regions.hg38.list"
+      intervals     = "$bundleDir/wgs_calling_regions_sorted.hg38.list"
       knownIndels   = [
         "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
         "$bundleDir/beta/Homo_sapiens_assembly38.known_indels.vcf.gz"

--- a/scripts/sort_intervals.py
+++ b/scripts/sort_intervals.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Parses a trace.txt file in which RunHaplotypecaller processes are recorded.
+Outputs a list of intervals sorted by runtime, longest duration first.
+
+Run like this:
+
+  ./sort_intervals.py < trace.txt > sorted.list
+"""
+import re
+import sys
+from itertools import islice
+
+
+duration_regex = re.compile('((?P<hours>[0-9]*)h )?((?P<minutes>[0-9]*)m )?((?P<seconds>[0-9]*)s)?')
+
+
+def parse_duration(s):
+    m = duration_regex.match(s)
+    if not m:
+        return None
+    t = 0
+    if m.group('hours'):
+        t += 3600 * int(m.group('hours'))
+    if m.group('minutes'):
+        t += 60 * int(m.group('minutes'))
+    if m.group('seconds'):
+        t += int(m.group('seconds'))
+    return t
+
+
+times = []
+for line in sys.stdin:
+    fields = line.split('\t')
+    name = fields[3]
+    if not name.startswith('RunHaplotypecaller'):
+        continue
+    duration = fields[14]
+    s = fields[3]
+    interval = s[s.find('chr'):-1].replace('_', ':')
+    times.append((parse_duration(duration), interval))
+times.sort(reverse=True)
+for duration, interval in times:
+    print(interval)


### PR DESCRIPTION
I’ve created a new `.list` file using the included script and added it to the hg38bundle directory on Uppmax. The script parses a trace.txt file and outputs a new (sorted) .list file.

I have not run that script for GRCh37.

Processing time goes down from 8h 11m to 7h 22m.

Closes #292