### PR TITLE
When extracting the VCF header, do not read the entire file

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -795,7 +795,7 @@ process ConcatVCF {
     """
     # first make a header from one of the VCF intervals
     # get rid of interval information only from the GATK command-line, but leave the rest
-    awk '/^#/{print}' `ls *vcf| head -1` | \
+    sed -n '/^[^#]/q;p' `ls *vcf| head -n 1` | \
     awk '!/GATKCommandLine/{print}/GATKCommandLine/{for(i=1;i<=NF;i++){if(\$i!~/intervals=/ && \$i !~ /out=/){printf("%s ",\$i)}}printf("\\n")}' \
     > header
 


### PR DESCRIPTION
The awk command reads in the full file (checking every line whether it is a
header line). The sed command stops on the first non-header line.