### PR TITLE
Do not explicitly create a recalibrated BAM if HaplotypeCaller is the only tool being run

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -429,7 +429,7 @@ process CreateRecalibrationTable {
   -o ${idSample}.recal.table
   """
 }
-// Creating a TSV file to restart from this step
+// Create a TSV file to restart from this step
 recalibrationTableTSV.map { idPatient, status, idSample, bam, bai, recalTable ->
   gender = patientGenders[idPatient]
   "$idPatient\t$gender\t$status\t$idSample\t$directoryMap.nonRecalibrated/$bam\t$directoryMap.nonRecalibrated/$bai\t\t$directoryMap.nonRecalibrated/$recalTable\n"
@@ -440,6 +440,12 @@ recalibrationTableTSV.map { idPatient, status, idSample, bam, bai, recalTable ->
 if (step == 'recalibrate') recalibrationTable = bamFiles
 
 if (verbose) recalibrationTable = recalibrationTable.view {"Base recalibrated table for RecalibrateBam: $it"}
+
+recalTables = Channel.create()
+recalibrationTableForHC = Channel.create()
+(recalTables, recalibrationTableForHC, recalibrationTable) = recalibrationTable.into(3)
+recalTables = recalTables.map { [it[0]] + it[2..-1] } // remove status
+if (verbose) recalTables = recalTables.view {"Recalibration tables: $it"}
 
 process RecalibrateBam {
   tag {idPatient + "-" + idSample}
@@ -459,7 +465,9 @@ process RecalibrateBam {
     set idPatient, status, idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bai") into recalibratedBam, recalibratedBamForStats
     set idPatient, status, idSample, val("${idSample}.recal.bam"), val("${idSample}.recal.bai") into recalibratedBamTSV
 
-  when: step != 'skippreprocessing'
+  // HaplotypeCaller can do BQSR on the fly, so do not create a
+  // recalibrated BAM explicitly.
+  when: step != 'skippreprocessing' && tools != ['haplotypecaller']
 
   script:
   """
@@ -518,6 +526,9 @@ if (verbose) recalibratedBamReport = recalibratedBamReport.view {"BAM Stats: $it
 // separate recalibrateBams by status
 bamsNormal = Channel.create()
 bamsTumor = Channel.create()
+if (tools == ['haplotypecaller']) {
+   recalibratedBam = recalibrationTableForHC.map { it[0..-2] }
+}
 recalibratedBam
   .choice(bamsTumor, bamsNormal) {it[1] == 0 ? 1 : 0}
 
@@ -561,6 +572,24 @@ intervals = Channel.
 bamsFHC = bamsNormalTemp.mix(bamsTumorTemp)
 if (verbose) bamsFHC = bamsFHC.view {"Bams with Intervals for HaplotypeCaller: $it"}
 
+if (verbose) recalTables = recalTables.view {"recalTables before spread: $it"}
+
+intervals = intervals.tap { intervalsTemp }
+recalTables = recalTables
+  .spread(intervalsTemp)
+  .map { patient, sample, bam, bai, recalTable, interval, interval2 ->
+    [patient, sample, bam, bai, interval, interval2, recalTable] }
+
+if (verbose) recalTables = recalTables.view {"recalTables with intervals: $it"}
+
+// re-associate the BAMs and samples with the recalibration table
+bamsFHC = bamsFHC
+  .phase(recalTables) { it[0..4] }
+  .map { it1, it2 -> it1 + [it2[6]] }
+
+if (verbose) bamsFHC = bamsFHC.view {"Bams with intervals and recal. table for HaplotypeCaller: $it"}
+
+
 bamsAll = bamsNormal.spread(bamsTumor)
 // Since idPatientNormal and idPatientTumor are the same
 // It's removed from bamsAll Channel (same for genderNormal)
@@ -593,11 +622,12 @@ if (verbose) bamsForManta = bamsForManta.view {"Bams for Manta: $it"}
 
 if (verbose) bamsForStrelka = bamsForStrelka.view {"Bams for Strelka: $it"}
 
+
 process RunHaplotypecaller {
   tag {idSample + "-" + gen_int}
 
   input:
-    set idPatient, idSample, file(bam), file(bai), genInt, gen_int from bamsFHC //Are these values `ped to bamNormal already?
+    set idPatient, idSample, file(bam), file(bai), genInt, gen_int, recalTable from bamsFHC //Are these values `ped to bamNormal already?
     set file(genomeFile), file(genomeIndex), file(genomeDict), file(dbsnp), file(dbsnpIndex) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
@@ -621,13 +651,13 @@ process RunHaplotypecaller {
   -pairHMM LOGLESS_CACHING \
   -R $genomeFile \
   --dbsnp $dbsnp \
+  --BQSR $recalTable \
   -I $bam \
   -L \"$genInt\" \
   --disable_auto_index_creation_and_locking_when_reading_rods \
   -o ${gen_int}_${idSample}.g.vcf
   """
 }
-
 hcGenomicVCF = hcGenomicVCF.groupTuple(by:[0,1,2,3])
 verbose ? hcGenomicVCF = hcGenomicVCF.view {"HaplotypeCaller output: $it"} : ''
 

--- a/main.nf
+++ b/main.nf
@@ -456,7 +456,7 @@ process RecalibrateBam {
     ])
 
   output:
-    set idPatient, status, idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bai") into recalibratedBam
+    set idPatient, status, idSample, file("${idSample}.recal.bam"), file("${idSample}.recal.bai") into recalibratedBam, recalibratedBamForStats
     set idPatient, status, idSample, val("${idSample}.recal.bam"), val("${idSample}.recal.bai") into recalibratedBamTSV
 
   when: step != 'skippreprocessing'
@@ -484,8 +484,6 @@ recalibratedBamTSV.map { idPatient, status, idSample, bam, bai ->
 if (step == 'skippreprocessing') recalibratedBam = bamFiles
 
 if (verbose) recalibratedBam = recalibratedBam.view {"Recalibrated BAM for variant Calling: $it"}
-
-(recalibratedBam, recalibratedBamForStats) = recalibratedBam.into(2)
 
 process RunSamtoolsStats {
   tag {idPatient + "-" + idSample}

--- a/scripts/test_docker.sh
+++ b/scripts/test_docker.sh
@@ -3,7 +3,6 @@ set -xeuo pipefail
 
 function nf_test() {
   nextflow run . -profile testing "$@"
-  echo "---------------------------"
 }
 
 nextflow run buildReferences.nf -profile testing --download
@@ -14,6 +13,7 @@ nf_test --test --step preprocessing --tools MultiQC
 # Clean up docker images
 docker rmi -f maxulysse/fastqc:1.1 maxulysse/mapreads:1.1 maxulysse/picard:1.1
 nf_test --step realign
+nf_test --step realign --tools HaplotypeCaller -resume
 nf_test --step recalibrate
 nf_test --step skipPreprocessing --tools FreeBayes,HaplotypeCaller,MultiQC,MuTect1,MuTect2,Strelka,VarDict
 # Clean up docker images


### PR DESCRIPTION
When HaplotypeCaller is the only requested tool, the pipeline now skips the RecalibrateBam process.

The option --BQSR is directly passed to HaplotypeCaller. This means that HaplotypeCaller does the base quality recalibration "on the fly". The results should be the same as before.

To clarify: Base quality recalibration is still done, we just never create the BAM file with recalibrated bases.

PrintReads, which was previously used to create the recalibrated BAM file, took around 19 hours. With this change, and when only HaplotypeCaller is run, these 19 hours are saved. HaplotypeCaller is a bit slower because it needs to recalibrate bases on-the-fly , but this is distributed over all HaplotypeCaller processes running in parallel (working on separate intervals). For calling variants on a full test genome, HaplotypeCaller now needs 12 instead of 11 hours. In total, we therefore save 18 hours.
Things to note:

- The base-recalibrated BAM file is still created if HaplotypeCaller is not the only requested tool.
- --BQSR is *always* passed to HaplotypeCaller, even when a recalibrated BAM is created.
- The same --BQSR option is (likely) also supported by MuTect and MuTect 2, so the same optimization could be applied.

Closes #281