### PR TITLE
Reduce ConcatVCF runtime on GVCF from 4 hours to 5 minutes

### DIFF
--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -38,7 +38,6 @@ process {
   $BuildVCFIndex {
   }
   $ConcatVCF {
-    cpus = 1
   }
   $CreateRecalibrationTable {
     memory = {params.singleCPUMem * 2 * task.attempt}

--- a/configuration/uppmax.config
+++ b/configuration/uppmax.config
@@ -24,7 +24,6 @@ process {
   $BuildVCFIndex {
   }
   $ConcatVCF {
-    cpus = 1
   }
   $CreateRecalibrationTable {
     time = {params.runTime * task.attempt}


### PR DESCRIPTION
Instead of using Picard’s SortVcf, we can simply concatenate the VCFs in the correct order. This works because we know that the VCFs do not overlap each other and because each of them is already sorted.

The ConcatVcf process previously took around 4-5 hours. One hour was spent in concatenating all files (with awk), much of the rest on Picard’s SortVcf, and some time on compressing the output.

With this change, ConcatVcf needs 5 minutes to create a 12 GB GVCF file, which previously took around 4 hours. This is not a typo.