### PR TITLE
hotfix for snpeff with GRCH38

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -55,7 +55,7 @@ params {
         "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
         "$bundleDir/beta/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
       ]
-      snpeffDb      = "GRCh38.86"
+      snpeffDb      = "GRCh38.82"
     }
     'smallGRCh37' {
       bundleDir   = 'References/smallGRCh37'


### PR DESCRIPTION
We were asking for `GRCh38.86`, but only `GRCh38.82` is available on bianca, so obviously it fails...