### PR TITLE
Removed unnecessary create

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1605,12 +1605,11 @@ def flowcellLaneFromFastq(path) {
 }
 
 def generateIntervalsForVC(bams, intervals) {
-  final bamsForVC = Channel.create()
-  final vcIntervals = Channel.create()
-  (bams, bamsForVC) = bams.into(2)
-  (intervals, vcIntervals) = intervals.into(2)
-  bamsForVC = bamsForVC.spread(vcIntervals)
-  return [bamsForVC, bams, intervals]
+
+  def (bamsNew, bamsForVC) = bams.into(2)
+  def (intervalsNew, vcIntervals) = intervals.into(2)
+  def bamsForVCNew = bamsForVC.spread(vcIntervals)
+  return [bamsForVCNew, bamsNew, intervalsNew]
 }
 
 def grabRevision() {


### PR DESCRIPTION
The `create` method is not necessary when assigning a channel with the `into` or any other operator (it's only needed when it need to specified as a parameter, as with the `choice` operator). 