### PR TITLE
Skip RecalibrateBam step in more situations; make skippreprocessing work

### DIFF
--- a/doc/USE_CASES.md
+++ b/doc/USE_CASES.md
@@ -79,7 +79,7 @@ At the end of this step you should have recalibrated BAM files in the `Preproces
 
 ## Starting from recalibration
 
-If the bam files were realigned together, you can start from recalibration:
+If the BAM files were realigned together, you can start from recalibration:
 
 ```bash
 nextflow run SciLifeLab/CAW --sample mysample.tsv --step recalibrate
@@ -106,6 +106,12 @@ And the corresponding TSV file should be like:
 SUBJECT_ID  XX    0    SAMPLEIDN    /samples/SAMPLEIDN.bam    /samples/SAMPLEIDN.bai
 SUBJECT_ID  XX    1    SAMPLEIDT    /samples/SAMPLEIDT.bam    /samples/SAMPLEIDT.bai
 ```
+
+If you want to restart a previous run of the pipeline, you may not have a recalibrated
+BAM file. This is the case if HaplotypeCaller was the only tool (recalibration is
+done on-the-fly with HaplotypeCaller to improve performance and save space). In
+this case, you need to start with `--step=recalibrate` (see previous section).
+
 
 --------------------------------------------------------------------------------
 

--- a/scripts/test_docker.sh
+++ b/scripts/test_docker.sh
@@ -15,8 +15,9 @@ nf_test . --test --step preprocessing --tools MultiQC
 docker rmi -f maxulysse/fastqc:1.1 maxulysse/mapreads:1.1 maxulysse/picard:1.1
 nf_test . --step realign
 nf_test . --step realign --tools HaplotypeCaller -resume
-nf_test . --step recalibrate
-nf_test . --step skipPreprocessing --tools FreeBayes,HaplotypeCaller,MultiQC,MuTect1,MuTect2,Strelka
+nf_test . --step recalibrate --tools FreeBayes,HaplotypeCaller,MultiQC,MuTect1,MuTect2,Strelka
+# Test whether restarting from an already recalibrated BAM works
+nf_test . --step skipPreprocessing --tools Strelka
 # Clean up docker images
 docker rmi -f maxulysse/concatvcf:1.1 maxulysse/freebayes:1.1 maxulysse/gatk:1.1 maxulysse/mutect1:1.1 maxulysse/samtools:1.1 maxulysse/strelka:1.1
 nf_test . --step skipPreprocessing --tools MuTect2,snpEff -resume

--- a/scripts/test_docker.sh
+++ b/scripts/test_docker.sh
@@ -2,6 +2,7 @@
 set -xeuo pipefail
 
 function nf_test() {
+  echo "$(tput setaf 1)nextflow run $@ -profile travis$(tput sgr0)"
   nextflow run "$@" -profile travis
 }
 


### PR DESCRIPTION
Only a defined list of tools triggers the recalibrated BAM to be created.
Previously, we would check only whether HaplotypeCaller is the only tool
being run, but that is too restrictive. Now, the RecalibrateBam step is
also omitted with --tools=HaplotypeCaller,MultiQC, for example.