### PR TITLE
Fix ConcatVCF on GRCh37

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -865,7 +865,7 @@ process ConcatVCF {
   > header
 
   # Get list of contigs from VCF header
-  CONTIGS=(\$(sed -rn '/^[^#]/q;/^##contig=/{s/##contig=<ID=(.*),length=[0-9]+>/\\1/;s/\\*/\\\\*/g;p}' \$FIRSTVCF))
+  CONTIGS=(\$(sed -rn '/^[^#]/q;/^##contig=/{s/##contig=<ID=(.*),length=[0-9]+(,[^>]*)?>/\\1/;s/\\*/\\\\*/g;p}' \$FIRSTVCF))
 
   # concatenate VCFs in the correct order
   (


### PR DESCRIPTION
The VCF header was not parsed correctly (it worked only on GRCh38)