### PR TITLE
simplified messages

### DIFF
--- a/buildReferences.nf
+++ b/buildReferences.nf
@@ -31,7 +31,6 @@ kate: syntax groovy; space-indent on; indent-width 2;
 ================================================================================
 */
 
-
 version = '1.1'
 
 if (!isAllowedParams(params)) {exit 1, "params is unknown, see --help for more information"}

--- a/buildReferences.nf
+++ b/buildReferences.nf
@@ -37,12 +37,12 @@ version = '1.1'
 if (!isAllowedParams(params)) {exit 1, "params is unknown, see --help for more information"}
 
 if (params.help) {
-  helpMessage(version)
+  helpMessage()
   exit 1
 }
 
 if (params.version) {
-  versionMessage(version)
+  versionMessage()
   exit 1
 }
 
@@ -89,7 +89,7 @@ if (!download) {referencesFiles.each{checkFile(params.refDir + "/" + it)}}
 ================================================================================
 */
 
-startMessage(version)
+startMessage()
 
 process ProcessReference {
   tag download ? {"Download: " + reference} : {"Link: " + reference}
@@ -298,7 +298,7 @@ def grabRevision() {
   return workflow.revision ?: workflow.scriptId.substring(0,10)
 }
 
-def helpMessage(version) { // Display help message
+def helpMessage() { // Display help message
   log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "    Usage:"
   log.info "       nextflow run buildReferences.nf --refDir <pathToRefDir> --genome <genome>"
@@ -330,7 +330,7 @@ def isAllowedParams(params) {
   return test
 }
 
-def startMessage(version) { // Display start message
+def startMessage() { // Display start message
   log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Command Line: $workflow.commandLine"
   log.info "Project Dir : $workflow.projectDir"
@@ -339,7 +339,7 @@ def startMessage(version) { // Display start message
   log.info "Genome      : " + params.genome
 }
 
-def versionMessage(version) { // Display version message
+def versionMessage() { // Display version message
   log.info "CANCER ANALYSIS WORKFLOW"
   log.info "  version   : $version"
   log.info workflow.commitId ? "Git info    : $workflow.repository - $workflow.revision [$workflow.commitId]" : "  revision  : " + this.grabRevision()

--- a/buildReferences.nf
+++ b/buildReferences.nf
@@ -247,6 +247,11 @@ process BuildVCFIndex {
 ================================================================================
 */
 
+def cawMessage() {
+  // Display CAW message
+  log.info "CANCER ANALYSIS WORKFLOW ~ $version - " + this.grabRevision() + (workflow.commitId ? " [$workflow.commitId]" : "")
+}
+
 def checkFile(it) {
   // Check file existence
   final f = file(it)
@@ -291,21 +296,24 @@ def checkParams(it) {
 }
 
 def checkUppmaxProject() {
-  return !((workflow.profile == 'standard' || workflow.profile == 'interactive') && !params.project)
+  // check if UPPMAX project number is specified
+  return !(workflow.profile == 'slurm' && !params.project)
 }
 
 def grabRevision() {
-  return workflow.revision ?: workflow.scriptId.substring(0,10)
+  // Return the same string executed from github or not
+  return workflow.revision ?: workflow.commitId ?: workflow.scriptId.substring(0,10)
 }
 
-def helpMessage() { // Display help message
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
+def helpMessage() {
+  // Display help message
+  this.cawMessage()
   log.info "    Usage:"
   log.info "       nextflow run buildReferences.nf --refDir <pathToRefDir> --genome <genome>"
   log.info "       nextflow run buildReferences.nf --download --genome smallGRCh37"
   log.info "       nextflow run SciLifeLab/CAW --test [--step STEP] [--tools TOOL[,TOOL]] --genome <Genome>"
   log.info "    --download"
-  log.info "       Download smallGRCh37 reference files."
+  log.info "       Download reference files. (only with --genome smallGRCh37)"
   log.info "    --refDir <Directoy>"
   log.info "       Specify a directory containing reference files."
   log.info "    --genome <Genome>"
@@ -320,6 +328,7 @@ def helpMessage() { // Display help message
 }
 
 def isAllowedParams(params) {
+  // Compare params to list of verified params
   final test = true
   params.each{
     if (!checkParams(it.toString().split('=')[0])) {
@@ -330,8 +339,8 @@ def isAllowedParams(params) {
   return test
 }
 
-def startMessage() { // Display start message
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
+def minimalInformationMessage() {
+  // Minimal information message
   log.info "Command Line: $workflow.commandLine"
   log.info "Project Dir : $workflow.projectDir"
   log.info "Launch Dir  : $workflow.launchDir"
@@ -339,20 +348,29 @@ def startMessage() { // Display start message
   log.info "Genome      : " + params.genome
 }
 
-def versionMessage() { // Display version message
+def nextflowMessage() {
+  // Nextflow message (version + build)
+  log.info "N E X T F L O W  ~  version $workflow.nextflow.version $workflow.nextflow.build"
+}
+
+def startMessage() {
+  // Display start message
+  this.cawMessage()
+  this.minimalInformationMessage()
+}
+
+def versionMessage() {
+  // Display version message
   log.info "CANCER ANALYSIS WORKFLOW"
   log.info "  version   : $version"
   log.info workflow.commitId ? "Git info    : $workflow.repository - $workflow.revision [$workflow.commitId]" : "  revision  : " + this.grabRevision()
 }
 
-workflow.onComplete { // Display complete message
-  log.info "N E X T F L O W ~ $workflow.nextflow.version - $workflow.nextflow.build"
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
-  log.info "Command Line: $workflow.commandLine"
-  log.info "Project Dir : $workflow.projectDir"
-  log.info "Launch Dir  : $workflow.launchDir"
-  log.info "Work Dir    : $workflow.workDir"
-  log.info "Genome      : " + params.genome
+workflow.onComplete {
+  // Display complete message
+  this.nextflowMessage()
+  this.cawMessage()
+  this.minimalInformationMessage()
   log.info "Completed at: $workflow.complete"
   log.info "Duration    : $workflow.duration"
   log.info "Success     : $workflow.success"
@@ -360,8 +378,9 @@ workflow.onComplete { // Display complete message
   log.info "Error report: " + (workflow.errorReport ?: '-')
 }
 
-workflow.onError { // Display error message
-  log.info "N E X T F L O W ~ version $workflow.nextflow.version [$workflow.nextflow.build]"
-  log.info workflow.commitId ? "CANCER ANALYSIS WORKFLOW ~ $version - $workflow.revision [$workflow.commitId]" : "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
+workflow.onError {
+  // Display error message
+  this.nextflowMessage()
+  this.cawMessage()
   log.info "Workflow execution stopped with the following message: " + workflow.errorMessage
 }

--- a/buildReferences.nf
+++ b/buildReferences.nf
@@ -21,28 +21,28 @@ kate: syntax groovy; space-indent on; indent-width 2;
  Pall Olason <pall.olason@scilifelab.se> [@pallolason]
  Pelin Sahlén <pelin.akan@scilifelab.se> [@pelinakan]
 --------------------------------------------------------------------------------
- @Homepage
- http://opensource.scilifelab.se/projects/caw/
+  @Homepage
+  http://opensource.scilifelab.se/projects/caw/
 --------------------------------------------------------------------------------
+  @Documentation
+  https://github.com/SciLifeLab/CAW/README.md
+================================================================================
+=                           C O N F I G U R A T I O N                          =
+================================================================================
 */
 
-/*
-================================================================================
-=                               P R O C E S S E S                              =
-================================================================================
-*/
 
 version = '1.1'
 
 if (!isAllowedParams(params)) {exit 1, "params is unknown, see --help for more information"}
 
 if (params.help) {
-  helpMessage(version, grabRevision())
+  helpMessage(version)
   exit 1
 }
 
 if (params.version) {
-  versionMessage(version, grabRevision())
+  versionMessage(version)
   exit 1
 }
 
@@ -82,6 +82,14 @@ if (params.genome == "smallGRCh37") {
 if (download && params.genome != "smallGRCh37") {exit 1, "Not possible to download $params.genome references files"}
 
 if (!download) {referencesFiles.each{checkFile(params.refDir + "/" + it)}}
+
+/*
+================================================================================
+=                               P R O C E S S E S                              =
+================================================================================
+*/
+
+startMessage(version)
 
 process ProcessReference {
   tag download ? {"Download: " + reference} : {"Link: " + reference}
@@ -290,8 +298,8 @@ def grabRevision() {
   return workflow.revision ?: workflow.scriptId.substring(0,10)
 }
 
-def helpMessage(version, revision) { // Display help message
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
+def helpMessage(version) { // Display help message
+  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "    Usage:"
   log.info "       nextflow run buildReferences.nf --refDir <pathToRefDir> --genome <genome>"
   log.info "       nextflow run buildReferences.nf --download --genome smallGRCh37"
@@ -322,8 +330,8 @@ def isAllowedParams(params) {
   return test
 }
 
-def startMessage(version, revision) { // Display start message
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
+def startMessage(version) { // Display start message
+  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Command Line: $workflow.commandLine"
   log.info "Project Dir : $workflow.projectDir"
   log.info "Launch Dir  : $workflow.launchDir"
@@ -331,15 +339,15 @@ def startMessage(version, revision) { // Display start message
   log.info "Genome      : " + params.genome
 }
 
-def versionMessage(version, revision) { // Display version message
+def versionMessage(version) { // Display version message
   log.info "CANCER ANALYSIS WORKFLOW"
   log.info "  version   : $version"
-  log.info workflow.commitId ? "Git info    : $workflow.repository - $workflow.revision [$workflow.commitId]" : "  revision  : $revision"
+  log.info workflow.commitId ? "Git info    : $workflow.repository - $workflow.revision [$workflow.commitId]" : "  revision  : " + this.grabRevision()
 }
 
 workflow.onComplete { // Display complete message
   log.info "N E X T F L O W ~ $workflow.nextflow.version - $workflow.nextflow.build"
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
+  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Command Line: $workflow.commandLine"
   log.info "Project Dir : $workflow.projectDir"
   log.info "Launch Dir  : $workflow.launchDir"
@@ -354,6 +362,6 @@ workflow.onComplete { // Display complete message
 
 workflow.onError { // Display error message
   log.info "N E X T F L O W ~ version $workflow.nextflow.version [$workflow.nextflow.build]"
-  log.info workflow.commitId ? "CANCER ANALYSIS WORKFLOW ~ $version - $workflow.revision [$workflow.commitId]" : "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
+  log.info workflow.commitId ? "CANCER ANALYSIS WORKFLOW ~ $version - $workflow.revision [$workflow.commitId]" : "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Workflow execution stopped with the following message: " + workflow.errorMessage
 }

--- a/main.nf
+++ b/main.nf
@@ -57,18 +57,17 @@ kate: syntax groovy; space-indent on; indent-width 2;
 ================================================================================
 */
 
-revision = grabRevision()
 version = '1.1'
 
 if (!isAllowedParams(params)) {exit 1, "params is unknown, see --help for more information"}
 
 if (params.help) {
-  helpMessage(version, revision)
+  helpMessage(version)
   exit 1
 }
 
 if (params.version) {
-  versionMessage(version, revision)
+  versionMessage(version)
   exit 1
 }
 
@@ -147,7 +146,7 @@ if (step == 'preprocessing') {
 
 if (verbose) fastqFiles = fastqFiles.view {"FASTQ files to preprocess: $it"}
 if (verbose) bamFiles = bamFiles.view {"BAM files to process: $it"}
-startMessage(version, grabRevision())
+startMessage(version)
 
 /*
 ================================================================================
@@ -1662,7 +1661,7 @@ def grabRevision() {
   return workflow.revision ?: workflow.commitId ?: workflow.scriptId.substring(0,10)
 }
 
-def helpMessage(version, revision) { // Display help message
+def helpMessage(version) { // Display help message
   log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
   log.info "    Usage:"
   log.info "       nextflow run SciLifeLab/CAW --sample <file.tsv> [--step STEP] [--tools TOOL[,TOOL]] --genome <Genome>"
@@ -1736,8 +1735,8 @@ def isAllowedParams(params) {
   return test
 }
 
-def startMessage(version, revision) { // Display start message
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
+def startMessage(version) { // Display start message
+  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Command Line: $workflow.commandLine"
   log.info "Project Dir : $workflow.projectDir"
   log.info "Launch Dir  : $workflow.launchDir"
@@ -1749,15 +1748,15 @@ def startMessage(version, revision) { // Display start message
   if (annotateTools) {log.info "Annotate on : " + annotateTools.join(', ')}
 }
 
-def versionMessage(version, revision) { // Display version message
+def versionMessage(version) { // Display version message
   log.info "CANCER ANALYSIS WORKFLOW"
   log.info "  version   : $version"
-  log.info workflow.commitId ? "Git info    : $workflow.repository - $workflow.revision [$workflow.commitId]" : "  revision  : $revision"
+  log.info workflow.commitId ? "Git info    : $workflow.repository - $workflow.revision [$workflow.commitId]" : "  revision  : " + this.grabRevision()
 }
 
 workflow.onComplete { // Display complete message
   log.info "N E X T F L O W ~ $workflow.nextflow.version - $workflow.nextflow.build"
-  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
+  log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Command Line: $workflow.commandLine"
   log.info "Project Dir : $workflow.projectDir"
   log.info "Launch Dir  : $workflow.launchDir"
@@ -1776,6 +1775,6 @@ workflow.onComplete { // Display complete message
 
 workflow.onError { // Display error message
   log.info "N E X T F L O W ~ version $workflow.nextflow.version [$workflow.nextflow.build]"
-  log.info workflow.commitId ? "CANCER ANALYSIS WORKFLOW ~ $version - $workflow.revision [$workflow.commitId]" : "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
+  log.info workflow.commitId ? "CANCER ANALYSIS WORKFLOW ~ $version - $workflow.revision [$workflow.commitId]" : "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Workflow execution stopped with the following message: " + workflow.errorMessage
 }

--- a/main.nf
+++ b/main.nf
@@ -146,13 +146,14 @@ if (step == 'preprocessing') {
 
 if (verbose) fastqFiles = fastqFiles.view {"FASTQ files to preprocess: $it"}
 if (verbose) bamFiles = bamFiles.view {"BAM files to process: $it"}
-startMessage()
 
 /*
 ================================================================================
 =                               P R O C E S S E S                              =
 ================================================================================
 */
+
+startMessage()
 
 (fastqFiles, fastqFilesforFastQC) = fastqFiles.into(2)
 

--- a/main.nf
+++ b/main.nf
@@ -62,12 +62,12 @@ version = '1.1'
 if (!isAllowedParams(params)) {exit 1, "params is unknown, see --help for more information"}
 
 if (params.help) {
-  helpMessage(version)
+  helpMessage()
   exit 1
 }
 
 if (params.version) {
-  versionMessage(version)
+  versionMessage()
   exit 1
 }
 
@@ -146,7 +146,7 @@ if (step == 'preprocessing') {
 
 if (verbose) fastqFiles = fastqFiles.view {"FASTQ files to preprocess: $it"}
 if (verbose) bamFiles = bamFiles.view {"BAM files to process: $it"}
-startMessage(version)
+startMessage()
 
 /*
 ================================================================================
@@ -1661,7 +1661,7 @@ def grabRevision() {
   return workflow.revision ?: workflow.commitId ?: workflow.scriptId.substring(0,10)
 }
 
-def helpMessage(version) { // Display help message
+def helpMessage() { // Display help message
   log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: $revision"
   log.info "    Usage:"
   log.info "       nextflow run SciLifeLab/CAW --sample <file.tsv> [--step STEP] [--tools TOOL[,TOOL]] --genome <Genome>"
@@ -1735,7 +1735,7 @@ def isAllowedParams(params) {
   return test
 }
 
-def startMessage(version) { // Display start message
+def startMessage() { // Display start message
   log.info "CANCER ANALYSIS WORKFLOW ~ $version - revision: " + this.grabRevision()
   log.info "Command Line: $workflow.commandLine"
   log.info "Project Dir : $workflow.projectDir"
@@ -1748,7 +1748,7 @@ def startMessage(version) { // Display start message
   if (annotateTools) {log.info "Annotate on : " + annotateTools.join(', ')}
 }
 
-def versionMessage(version) { // Display version message
+def versionMessage() { // Display version message
   log.info "CANCER ANALYSIS WORKFLOW"
   log.info "  version   : $version"
   log.info workflow.commitId ? "Git info    : $workflow.repository - $workflow.revision [$workflow.commitId]" : "  revision  : " + this.grabRevision()


### PR DESCRIPTION
- `helpMessage()`, `startMessage()` and `versionMessage()` now take no argument as `revision` can be find using `this.grabRevision()`, and `$version` was already global.
- add `cawMessage()`, `minimalInformationMessage()` and `nextflowMessage()` to display messages that are repeated in other messages.
- change `checkFile()`, `checkStatus()` and `checkTSV()` to `returnFile()`, `returnStatus()` and `returnTSV()` respectively