### PR TITLE
remove mutect1 from tests + fix typo

### DIFF
--- a/scripts/test_singularity.sh
+++ b/scripts/test_singularity.sh
@@ -13,10 +13,9 @@ nf_test . --step realign --noReports
 nf_test . --step realign --tools HaplotypeCaller
 nf_test . --step realign --tools HaplotypeCaller --noReports --noGVCF
 nf_test . --step recalibrate --noReports
-nf_test . --step recalibrate --tools FreeBayes,HaplotypeCaller,MuTect1,MuTect2,Strelka
+nf_test . --step recalibrate --tools FreeBayes,HaplotypeCaller,MuTect2,Strelka
 # Test whether restarting from an already recalibrated BAM works
 nf_test . --step skipPreprocessing --tools Strelka --noReports
-maxulysse/gatk:1.1 maxulysse/mutect1:1.1 maxulysse/samtools:1.1 maxulysse/strelka:1.1
 nf_test . --step skipPreprocessing --tools MuTect2,snpEff,VEP --noReports
 nf_test . --step annotate --tools snpEff,VEP --annotateTools MuTect2
 nf_test . --step annotate --tools snpEff,VEP --annotateVCF VariantCalling/MuTect2/mutect2_9876T_vs_1234N.vcf.gz,VariantCalling/MuTect2/mutect2_9877R_vs_1234N.vcf.gz --noReports


### PR DESCRIPTION
Singularity is not working with `openjdk7`, so our MuTect1 container is not working.
- removed it from tests
- remove typos (leftover from excessive copy/paste)