### PR TITLE
Install Singularity on TravisCI only when necessary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,18 +17,8 @@ env:
   - NXF_VER=0.25.6 SGT_VER=2.3.1 PROFILE=singularityTest TEST=MAPPING
   - NXF_VER=0.25.6 SGT_VER=2.3.1 PROFILE=travis TEST=MAPPING
 
-install:
-  - curl -fsSL get.nextflow.io | bash
-  - chmod +x nextflow
-  - sudo mv nextflow /usr/local/bin/
-  - wget https://github.com/singularityware/singularity/releases/download/$SGT_VER/singularity-$SGT_VER.tar.gz
-  - tar xvf singularity-$SGT_VER.tar.gz
-  - cd singularity-$SGT_VER
-  - ./configure --prefix=/usr/local
-  - make
-  - sudo make install
-  - cd ..
-  - rm -rf singularity-$SGT_VER*
+install: # Install Nextflow
+  - "./scripts/install.sh -t nextflow"
 
 script:
   - "./scripts/test.sh -p $PROFILE -t $TEST"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
   - NXF_VER=0.25.6 SGT_VER=2.3.1 PROFILE=travis TEST=MAPPING
 
 install: # Install Nextflow
-  - "./scripts/install.sh -t nextflow"
+  - "./scripts/install.sh --tool nextflow"
 
 script:
-  - "./scripts/test.sh -p $PROFILE -t $TEST"
+  - "./scripts/test.sh --profile $PROFILE --test $TEST --install --travisci"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -16,7 +16,7 @@ do
 done
 
 # Install Nextflow
-if [ $TOOL = nextflow ] || [ $TOOL = all ]
+if [[ "$TOOL" = nextflow ]] || [[ "$TOOL" = all ]]
 then
   curl -fsSL get.nextflow.io | bash
   chmod +x nextflow
@@ -24,7 +24,7 @@ then
 fi
 
 # Install Singularity
-if [ $TOOL = singularity ] || [ $TOOL = all ]
+if [[ "$TOOL" = singularity ]] || [[ "$TOOL" = all ]]
 then
   wget https://github.com/singularityware/singularity/releases/download/$SGT_VER/singularity-$SGT_VER.tar.gz
   tar xvf singularity-$SGT_VER.tar.gz

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+TOOL="nextflow"
+
+while [[ $# -gt 1 ]]
+do
+    key="$1"
+    case $key in
+        -t|--tool)
+        TOOL="$2"
+        shift
+        ;;
+        *) # unknown option
+        ;;
+    esac
+    shift
+done
+
+# Install Nextflow
+if [ $TOOL = nextflow ] || [ $TOOL = all ]
+then
+  curl -fsSL get.nextflow.io | bash
+  chmod +x nextflow
+  sudo mv nextflow /usr/local/bin/
+fi
+
+# Install Singularity
+if [ $TOOL = singularity ] || [ $TOOL = all ]
+then
+  wget https://github.com/singularityware/singularity/releases/download/$SGT_VER/singularity-$SGT_VER.tar.gz
+  tar xvf singularity-$SGT_VER.tar.gz
+  cd singularity-$SGT_VER
+  ./configure --prefix=/usr/local
+  make
+  sudo make install
+  cd ..
+  rm -rf singularity-$SGT_VER*
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -12,11 +12,9 @@ do
   case $key in
     -c|--travisci)
     TRAVIS=true
-    shift
     ;;
     -i|--install)
     INSTALL=true
-    shift
     ;;
     -p|--profile)
     PROFILE="$2"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -33,7 +33,7 @@ do
 done
 
 # Install Singularity
-if [[ "$PROFILE" == singularityTest ]] && [[ "$INSTALL" == true ]] && [[ "$TRAVIS" == true ]]
+if [[ "$PROFILE" == singularityTest ]] && [[ "$INSTALL" == true ]]
 then
   ./scripts/install.sh -t singularity
 fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,29 +1,39 @@
 #!/bin/bash
 set -xeuo pipefail
 
+INSTALL=false
 PROFILE="singularityTest"
 TEST="ALL"
+TRAVIS=false
 
-while [[ $# -gt 1 ]]
+while [[ $# -gt 0 ]]
 do
-    key="$1"
-    case $key in
-        -p|--profile)
-        PROFILE="$2"
-        shift
-        ;;
-        -t|--test)
-        TEST="$2"
-        shift
-        ;;
-        *) # unknown option
-        ;;
-    esac
+  key="$1"
+  case $key in
+    -c|--travisci)
+    TRAVIS=true
     shift
+    ;;
+    -i|--install)
+    INSTALL=true
+    shift
+    ;;
+    -p|--profile)
+    PROFILE="$2"
+    shift
+    ;;
+    -t|--test)
+    TEST="$2"
+    shift
+    ;;
+    *) # unknown option
+    ;;
+  esac
+  shift
 done
 
 # Install Singularity
-if [ $PROFILE = singularityTest ]
+if [[ "$PROFILE" == singularityTest ]] && [[ "$INSTALL" == true ]] && [[ "$TRAVIS" == true ]]
 then
   ./scripts/install.sh -t singularity
 fi
@@ -31,25 +41,26 @@ fi
 
 function nf_test() {
   echo "$(tput setaf 1)nextflow run $@ -profile $PROFILE -resume --verbose$(tput sgr0)"
-  nextflow run "$@" -profile $PROFILE -resume --verbose
+  nextflow run "$@" -profile "$PROFILE" -resume --verbose
 }
 
 nf_test buildReferences.nf --download
 
 #remove images
-if [ $PROFILE = travis ]
+if [[ "$PROFILE" == travis ]] && [[ "$TRAVIS" == true ]]
 then
   docker rmi -f maxulysse/igvtools:1.1
-else
+else if [[ "$PROFILE" == singularityTest ]] && [[ "$TRAVIS" == true ]]
+then
   rm -rf work/singularity/igvtools-1.1.img
 fi
 
-if [ $TEST = MAPPING ] || [ $TEST = ALL ]
+if [[ "$TEST" = MAPPING ]] || [[ "$TEST" = ALL ]]
 then
   nf_test . --test --step preprocessing
 fi
 
-if [ $TEST = REALIGN ] || [ $TEST = ALL ]
+if [[ "$TEST" = REALIGN ]] || [[ "$TEST" = ALL ]]
 then
   nf_test . --test --step preprocessing
   nf_test . --step realign --noReports
@@ -57,7 +68,7 @@ then
   nf_test . --step realign --tools HaplotypeCaller --noReports --noGVCF
 fi
 
-if [ $TEST = RECALIBRATE ] || [ $TEST = ALL ]
+if [[ "$TEST" = RECALIBRATE ]] || [[ "$TEST" = ALL ]]
 then
   nf_test . --test --step preprocessing
   nf_test . --step recalibrate --noReports
@@ -66,16 +77,17 @@ then
   nf_test . --step skipPreprocessing --tools Strelka --noReports
 fi
 
-if [ $TEST = ANNOTATE ] || [ $TEST = ALL ]
+if [[ "$TEST" = ANNOTATE ]] || [[ "$TEST" = ALL ]]
 then
   nf_test . --step preprocessing --sample data/tsv/tiny-manta.tsv --tools Manta
   nf_test . --test --step preprocessing --tools MuTect2,Strelka
 
   #remove images
-  if [ $PROFILE = travis ]
+  if [[ "$PROFILE" == travis ]] && [[ "$TRAVIS" == true ]]
   then
     docker rmi -f maxulysse/concatvcf:1.1 maxulysse/fastqc:1.1 maxulysse/gatk:1.0 maxulysse/gatk:1.1 maxulysse/mapreads:1.1 maxulysse/picard:1.1 maxulysse/runmanta:1.1 maxulysse/samtools:1.1 maxulysse/strelka:1.1
-  else
+  else if [[ "$PROFILE" == singularityTest ]] && [[ "$TRAVIS" == true ]]
+  then
     rm -rf work/singularity/concatvcf-1.1.img work/singularity/fastqc-1.1.img work/singularity/gatk-1.0.img work/singularity/gatk-1.1.img work/singularity/mapreads-1.1.img work/singularity/picard-1.1.img work/singularity/runmanta-1.1.img work/singularity/samtools-1.1.img work/singularity/strelka-1.1.img
   fi
 

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-set -xeuo pipefail
-
 INSTALL=false
 PROFILE="singularityTest"
 TEST="ALL"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -22,6 +22,13 @@ do
     shift
 done
 
+# Install Singularity
+if [ $PROFILE = singularityTest ]
+then
+  ./scripts/install.sh -t singularity
+fi
+
+
 function nf_test() {
   echo "$(tput setaf 1)nextflow run $@ -profile $PROFILE -resume --verbose$(tput sgr0)"
   nextflow run "$@" -profile $PROFILE -resume --verbose

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -xeuo pipefail
+
 INSTALL=false
 PROFILE="singularityTest"
 TEST="ALL"
@@ -36,7 +38,6 @@ then
   ./scripts/install.sh -t singularity
 fi
 
-
 function nf_test() {
   echo "$(tput setaf 1)nextflow run $@ -profile $PROFILE -resume --verbose$(tput sgr0)"
   nextflow run "$@" -profile "$PROFILE" -resume --verbose
@@ -45,20 +46,20 @@ function nf_test() {
 nf_test buildReferences.nf --download
 
 #remove images
-if [[ "$PROFILE" == travis ]] && [[ "$TRAVIS" == true ]]
+if [[ "$PROFILE" == "travis" ]] && [[ "$TRAVIS" == true ]]
 then
   docker rmi -f maxulysse/igvtools:1.1
-else if [[ "$PROFILE" == singularityTest ]] && [[ "$TRAVIS" == true ]]
+elif [[ "$PROFILE" == singularityTest ]] && [[ "$TRAVIS" == true ]]
 then
   rm -rf work/singularity/igvtools-1.1.img
 fi
 
-if [[ "$TEST" = MAPPING ]] || [[ "$TEST" = ALL ]]
+if [[ "$TEST" = "MAPPING" ]] || [[ "$TEST" = "ALL" ]]
 then
   nf_test . --test --step preprocessing
 fi
 
-if [[ "$TEST" = REALIGN ]] || [[ "$TEST" = ALL ]]
+if [[ "$TEST" = "REALIGN" ]] || [[ "$TEST" = "ALL" ]]
 then
   nf_test . --test --step preprocessing
   nf_test . --step realign --noReports
@@ -66,7 +67,7 @@ then
   nf_test . --step realign --tools HaplotypeCaller --noReports --noGVCF
 fi
 
-if [[ "$TEST" = RECALIBRATE ]] || [[ "$TEST" = ALL ]]
+if [[ "$TEST" = "RECALIBRATE" ]] || [[ "$TEST" = "ALL" ]]
 then
   nf_test . --test --step preprocessing
   nf_test . --step recalibrate --noReports
@@ -75,20 +76,19 @@ then
   nf_test . --step skipPreprocessing --tools Strelka --noReports
 fi
 
-if [[ "$TEST" = ANNOTATE ]] || [[ "$TEST" = ALL ]]
+if [[ "$TEST" = "ANNOTATE" ]] || [[ "$TEST" = "ALL" ]]
 then
   nf_test . --step preprocessing --sample data/tsv/tiny-manta.tsv --tools Manta
   nf_test . --test --step preprocessing --tools MuTect2,Strelka
 
   #remove images
-  if [[ "$PROFILE" == travis ]] && [[ "$TRAVIS" == true ]]
+  if [[ "$PROFILE" == "travis" ]] && [[ "$TRAVIS" == true ]]
   then
     docker rmi -f maxulysse/concatvcf:1.1 maxulysse/fastqc:1.1 maxulysse/gatk:1.0 maxulysse/gatk:1.1 maxulysse/mapreads:1.1 maxulysse/picard:1.1 maxulysse/runmanta:1.1 maxulysse/samtools:1.1 maxulysse/strelka:1.1
-  else if [[ "$PROFILE" == singularityTest ]] && [[ "$TRAVIS" == true ]]
+  elif [[ "$PROFILE" == "singularityTest" ]] && [[ "$TRAVIS" == true ]]
   then
     rm -rf work/singularity/concatvcf-1.1.img work/singularity/fastqc-1.1.img work/singularity/gatk-1.0.img work/singularity/gatk-1.1.img work/singularity/mapreads-1.1.img work/singularity/picard-1.1.img work/singularity/runmanta-1.1.img work/singularity/samtools-1.1.img work/singularity/strelka-1.1.img
   fi
-
   nf_test . --step annotate --tools snpEff,VEP --annotateTools Strelka
   nf_test . --step annotate --tools snpEff --annotateVCF VariantCalling/Manta/Manta_9876T_vs_1234N.diploidSV.vcf,VariantCalling/Manta/Manta_9876T_vs_1234N.somaticSV.vcf --noReports
 fi


### PR DESCRIPTION
- Add a new install script
- Use it to install Nextflow in the install step
- Install Singularity (but in the script step) only when testing with Singularity
- Remove containers only when running on TravisCI

The idea is to be able to run this testing script for all tests (on personal computers and on Travis).
By default the test will be a singularity test.