### PR TITLE
Resource configuration cleanup

### DIFF
--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -19,12 +19,20 @@ params {
 }
 
 process {
+  // Default process resources
+
+  // A process may use one core,
   cpus = 1
+
+  // 8 GB of memory,
+  memory = {params.singleCPUMem}
+
+  // and 16 of them are allowed to be launched simultaneously.
   maxForks = 16
+
   errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
   maxErrors = '-1'
   maxRetries = 3
-  memory = {params.singleCPUMem}
 
   // These processes are defined in buildReferences.nf
 
@@ -97,15 +105,12 @@ process {
     memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
   }
   $RunGenotypeGVCFs {
-    memory = {params.singleCPUMem}
   }
   $RunManta {
     cpus = 16
     memory = {params.totalMemory}
   }
   $RunMultiQC {
-    memory = {params.singleCPUMem}
-    errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunMutect1 {
     memory = {params.singleCPUMem * task.attempt}

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -22,23 +22,26 @@ process {
   cpus = 1
   errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
   maxErrors = '-1'
-  maxForks = 2  // number of processess launched. If your process is using only a single CPU, and not that much memory, you can increase this value
   maxRetries = 3
   memory = {params.singleCPUMem}
 
   // These processes are defined in buildReferences.nf
 
   $BuildBWAindexes {
-    memory = {params.totalMemory}
+    maxForks = 2
+    memory = {params.totalMemory}  // TODO This is likely too high
   }
   $BuildPicardIndex {
-    memory = {params.totalMemory}
+    maxForks = 2
+    memory = {params.totalMemory}  // TODO This is likely too high
   }
   $BuildSAMToolsIndex {
-    memory = {params.totalMemory}
+    maxForks = 2
+    memory = {params.totalMemory}  // TODO This is likely too high
   }
   $BuildVCFIndex {
-    memory = {params.totalMemory}
+    maxForks = 2
+    memory = {params.totalMemory}  // TODO This is likely too high
   }
 
   // These processes are defined in main.nf
@@ -52,6 +55,7 @@ process {
     memory = {params.totalMemory}
   }
   $IndelRealigner {
+    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MapReads {
@@ -59,6 +63,7 @@ process {
     memory = {params.totalMemory}
   }
   $MarkDuplicates {
+    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MergeBams {
@@ -66,16 +71,20 @@ process {
     memory = {params.totalMemory}
   }
   $RealignerTargetCreator {
+    maxForks = 2
     cpus = 4
     memory = {params.singleCPUMem * 4 * task.attempt}
   }
   $RecalibrateBam {
+    maxForks = 2
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunAlleleCount {
+    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunAscat {
+    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunBamQC {
@@ -83,11 +92,14 @@ process {
     memory = {params.totalMemory}
   }
   $RunBcftoolsStats {
+    maxForks = 2
   }
   $RunConvertAlleleCounts {
+    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
+    maxForks = 2
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
@@ -95,10 +107,11 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunHaplotypecaller {
-    memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
     maxForks = 16  // if you are running out of memory on a single node, due to task re-runs, decrease this value
+    memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
   }
   $RunGenotypeGVCFs {
+    maxForks = 2
     memory = {params.singleCPUMem}
   }
   $RunManta {
@@ -106,6 +119,7 @@ process {
     memory = {params.totalMemory}
   }
   $RunMultiQC {
+    maxForks = 2
     memory = {params.singleCPUMem}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
@@ -118,8 +132,10 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunSamtoolsStats {
+    maxForks = 2
   }
   $RunSnpeff {
+    maxForks = 2
     memory = {params.totalMemory}  // TODO Does SnpEff really require that much?
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
@@ -128,6 +144,7 @@ process {
     memory = {params.totalMemory}
   }
   $RunVEP {
+    maxForks = 2
     memory = {params.totalMemory}  // TODO Does VEP really require that much?
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -20,6 +20,7 @@ params {
 
 process {
   cpus = 1
+  maxForks = 16
   errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
   maxErrors = '-1'
   maxRetries = 3
@@ -103,11 +104,9 @@ process {
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
-    maxForks = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunHaplotypecaller {
-    maxForks = 16  // if you are running out of memory on a single node, due to task re-runs, decrease this value
     memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
   }
   $RunGenotypeGVCFs {
@@ -124,11 +123,9 @@ process {
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunMutect1 {
-    maxForks = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunMutect2 {
-    maxForks = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunSamtoolsStats {

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -18,6 +18,7 @@ params {
 }
 
 process {
+  cpus = 1
   errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
   maxErrors = '-1'
   maxForks = 2  // number of processess launched. If your process is using only a single CPU, and not that much memory, you can increase this value
@@ -44,7 +45,6 @@ process {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $IndelRealigner {
-    cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MapReads {
@@ -52,7 +52,6 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $MarkDuplicates {
-    cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MergeBams {
@@ -68,21 +67,17 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunAlleleCount {
-    cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunAscat {
-    cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunBamQC {
     cpus = 16
   }
   $RunBcftoolsStats {
-    cpus = 1
   }
   $RunConvertAlleleCounts {
-    cpus = 1
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
@@ -90,48 +85,39 @@ process {
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
-    cpus = 1
     maxForks = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunHaplotypecaller {
-    cpus = 1
     memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
     maxForks = 16  // if you are running out of memory on a single node, due to task re-runs, decrease this value
   }
   $RunGenotypeGVCFs {
-    cpus = 1
     memory = {params.singleCPUMem}
   }
   $RunManta {
     cpus = 16
   }
   $RunMultiQC {
-    cpus = 1
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunMutect1 {
-    cpus = 1
     maxForks = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunMutect2 {
-    cpus = 1
     maxForks = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunSamtoolsStats {
-    cpus = 1
   }
   $RunSnpeff {
-    cpus = 1
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunStrelka {
     cpus = 16
   }
   $RunVEP {
-    cpus = 1
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -26,16 +26,12 @@ process {
   memory = 104.GB  // default assigned memory value for a single process
 
   $BuildBWAindexes {
-    cpus = 16
   }
   $BuildPicardIndex {
-    cpus = 16
   }
   $BuildSAMToolsIndex {
-    cpus = 16
   }
   $BuildVCFIndex {
-    cpus = 16
   }
   $ConcatVCF {
     cpus = 16
@@ -63,7 +59,6 @@ process {
     memory = {params.singleCPUMem * 4 * task.attempt}
   }
   $RecalibrateBam {
-    cpus = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunAlleleCount {
@@ -81,7 +76,6 @@ process {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
-    cpus = 16
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -4,8 +4,8 @@ vim: syntax=groovy
  * -------------------------------------------------
  * Nextflow config file for CAW project
  * -------------------------------------------------
- * Configuration for a UPPMAX localhost
- * (ie interactive mode on milou / a node on bianca)
+ * Configuration for running on a single UPPMAX node
+ * such as milou or bianca
  * -------------------------------------------------
  */
 
@@ -15,6 +15,7 @@ env {
 
 params {
   singleCPUMem  = 8.GB
+  totalMemory = 104.GB
 }
 
 process {
@@ -27,22 +28,22 @@ process {
   // These processes are defined in buildReferences.nf
 
   $BuildBWAindexes {
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $BuildPicardIndex {
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $BuildSAMToolsIndex {
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $BuildVCFIndex {
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
 
   // These processes are defined in main.nf
 
   $ConcatVCF {
-    memory = 104.GB
+    memory = {params.totalMemory}
     cpus = 16
   }
   $CreateRecalibrationTable {
@@ -78,16 +79,16 @@ process {
   }
   $RunBamQC {
     cpus = 16
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $RunBcftoolsStats {
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $RunConvertAlleleCounts {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
-    memory = 104.GB
+    memory = {params.totalMemory}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
@@ -103,10 +104,10 @@ process {
   }
   $RunManta {
     cpus = 16
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $RunMultiQC {
-    memory = 104.GB
+    memory = {params.totalMemory}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunMutect1 {
@@ -118,18 +119,18 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunSamtoolsStats {
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $RunSnpeff {
-    memory = 104.GB
+    memory = {params.totalMemory}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunStrelka {
     cpus = 16
-    memory = 104.GB
+    memory = {params.totalMemory}
   }
   $RunVEP {
-    memory = 104.GB
+    memory = {params.totalMemory}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -25,6 +25,8 @@ process {
   maxRetries = 3
   memory = 104.GB  // default assigned memory value for a single process
 
+  // These processes are defined in buildReferences.nf
+
   $BuildBWAindexes {
   }
   $BuildPicardIndex {
@@ -33,6 +35,9 @@ process {
   }
   $BuildVCFIndex {
   }
+
+  // These processes are defined in main.nf
+
   $ConcatVCF {
     cpus = 16
   }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -18,7 +18,6 @@ params {
 }
 
 process {
-  cpus = 16  // this is the default for example when a multithreaded process uses all the available CPUs
   errorStrategy = {task.exitStatus == 143 ? 'retry' : 'terminate'}
   maxErrors = '-1'
   maxForks = 2  // number of processess launched. If your process is using only a single CPU, and not that much memory, you can increase this value
@@ -26,16 +25,22 @@ process {
   memory = 104.GB  // default assigned memory value for a single process
 
   $BuildBWAindexes {
+    cpus = 16
   }
   $BuildPicardIndex {
+    cpus = 16
   }
   $BuildSAMToolsIndex {
+    cpus = 16
   }
   $BuildVCFIndex {
+    cpus = 16
   }
   $ConcatVCF {
+    cpus = 16
   }
   $CreateRecalibrationTable {
+    cpus = 16
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $IndelRealigner {
@@ -43,6 +48,7 @@ process {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MapReads {
+    cpus = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $MarkDuplicates {
@@ -50,13 +56,15 @@ process {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MergeBams {
+    cpus = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RealignerTargetCreator {
-    memory = {params.singleCPUMem * 4 * task.attempt}
     cpus = 4
+    memory = {params.singleCPUMem * 4 * task.attempt}
   }
   $RecalibrateBam {
+    cpus = 16
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunAlleleCount {
@@ -68,6 +76,7 @@ process {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunBamQC {
+    cpus = 16
   }
   $RunBcftoolsStats {
     cpus = 1
@@ -77,6 +86,7 @@ process {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
+    cpus = 16
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
@@ -94,6 +104,7 @@ process {
     memory = {params.singleCPUMem}
   }
   $RunManta {
+    cpus = 16
   }
   $RunMultiQC {
     cpus = 1
@@ -117,6 +128,7 @@ process {
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunStrelka {
+    cpus = 16
   }
   $RunVEP {
     cpus = 1

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -23,22 +23,26 @@ process {
   maxErrors = '-1'
   maxForks = 2  // number of processess launched. If your process is using only a single CPU, and not that much memory, you can increase this value
   maxRetries = 3
-  memory = 104.GB  // default assigned memory value for a single process
 
   // These processes are defined in buildReferences.nf
 
   $BuildBWAindexes {
+    memory = 104.GB
   }
   $BuildPicardIndex {
+    memory = 104.GB
   }
   $BuildSAMToolsIndex {
+    memory = 104.GB
   }
   $BuildVCFIndex {
+    memory = 104.GB
   }
 
   // These processes are defined in main.nf
 
   $ConcatVCF {
+    memory = 104.GB
     cpus = 16
   }
   $CreateRecalibrationTable {
@@ -74,13 +78,16 @@ process {
   }
   $RunBamQC {
     cpus = 16
+    memory = 104.GB
   }
   $RunBcftoolsStats {
+    memory = 104.GB
   }
   $RunConvertAlleleCounts {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
+    memory = 104.GB
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
@@ -96,8 +103,10 @@ process {
   }
   $RunManta {
     cpus = 16
+    memory = 104.GB
   }
   $RunMultiQC {
+    memory = 104.GB
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunMutect1 {
@@ -109,14 +118,18 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunSamtoolsStats {
+    memory = 104.GB
   }
   $RunSnpeff {
+    memory = 104.GB
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunStrelka {
     cpus = 16
+    memory = 104.GB
   }
   $RunVEP {
+    memory = 104.GB
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -29,19 +29,15 @@ process {
   // These processes are defined in buildReferences.nf
 
   $BuildBWAindexes {
-    maxForks = 2
     memory = {params.totalMemory}  // TODO This is likely too high
   }
   $BuildPicardIndex {
-    maxForks = 2
     memory = {params.totalMemory}  // TODO This is likely too high
   }
   $BuildSAMToolsIndex {
-    maxForks = 2
     memory = {params.totalMemory}  // TODO This is likely too high
   }
   $BuildVCFIndex {
-    maxForks = 2
     memory = {params.totalMemory}  // TODO This is likely too high
   }
 
@@ -56,7 +52,6 @@ process {
     memory = {params.totalMemory}
   }
   $IndelRealigner {
-    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MapReads {
@@ -64,7 +59,6 @@ process {
     memory = {params.totalMemory}
   }
   $MarkDuplicates {
-    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MergeBams {
@@ -72,20 +66,16 @@ process {
     memory = {params.totalMemory}
   }
   $RealignerTargetCreator {
-    maxForks = 2
     cpus = 4
     memory = {params.singleCPUMem * 4 * task.attempt}
   }
   $RecalibrateBam {
-    maxForks = 2
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunAlleleCount {
-    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunAscat {
-    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunBamQC {
@@ -93,14 +83,11 @@ process {
     memory = {params.totalMemory}
   }
   $RunBcftoolsStats {
-    maxForks = 2
   }
   $RunConvertAlleleCounts {
-    maxForks = 2
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
-    maxForks = 2
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
@@ -110,7 +97,6 @@ process {
     memory = {params.singleCPUMem * task.attempt * task.attempt } // this way the memory will increase quadratically as 8G, 32G, 72G
   }
   $RunGenotypeGVCFs {
-    maxForks = 2
     memory = {params.singleCPUMem}
   }
   $RunManta {
@@ -118,7 +104,6 @@ process {
     memory = {params.totalMemory}
   }
   $RunMultiQC {
-    maxForks = 2
     memory = {params.singleCPUMem}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
@@ -129,10 +114,8 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunSamtoolsStats {
-    maxForks = 2
   }
   $RunSnpeff {
-    maxForks = 2
     memory = {params.totalMemory}  // TODO Does SnpEff really require that much?
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
@@ -141,7 +124,6 @@ process {
     memory = {params.totalMemory}
   }
   $RunVEP {
-    maxForks = 2
     memory = {params.totalMemory}  // TODO Does VEP really require that much?
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }

--- a/configuration/localhost.config
+++ b/configuration/localhost.config
@@ -24,6 +24,7 @@ process {
   maxErrors = '-1'
   maxForks = 2  // number of processess launched. If your process is using only a single CPU, and not that much memory, you can increase this value
   maxRetries = 3
+  memory = {params.singleCPUMem}
 
   // These processes are defined in buildReferences.nf
 
@@ -43,26 +44,26 @@ process {
   // These processes are defined in main.nf
 
   $ConcatVCF {
-    memory = {params.totalMemory}
     cpus = 16
+    memory = {params.totalMemory}
   }
   $CreateRecalibrationTable {
     cpus = 16
-    memory = {params.singleCPUMem * 2 * task.attempt}
+    memory = {params.totalMemory}
   }
   $IndelRealigner {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MapReads {
     cpus = 16
-    memory = {params.singleCPUMem * task.attempt}
+    memory = {params.totalMemory}
   }
   $MarkDuplicates {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $MergeBams {
     cpus = 16
-    memory = {params.singleCPUMem * task.attempt}
+    memory = {params.totalMemory}
   }
   $RealignerTargetCreator {
     cpus = 4
@@ -82,13 +83,11 @@ process {
     memory = {params.totalMemory}
   }
   $RunBcftoolsStats {
-    memory = {params.totalMemory}
   }
   $RunConvertAlleleCounts {
     memory = {params.singleCPUMem * 2 * task.attempt}
   }
   $RunFastQC {
-    memory = {params.totalMemory}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunFreeBayes {
@@ -107,7 +106,7 @@ process {
     memory = {params.totalMemory}
   }
   $RunMultiQC {
-    memory = {params.totalMemory}
+    memory = {params.singleCPUMem}
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunMutect1 {
@@ -119,10 +118,9 @@ process {
     memory = {params.singleCPUMem * task.attempt}
   }
   $RunSamtoolsStats {
-    memory = {params.totalMemory}
   }
   $RunSnpeff {
-    memory = {params.totalMemory}
+    memory = {params.totalMemory}  // TODO Does SnpEff really require that much?
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
   $RunStrelka {
@@ -130,7 +128,7 @@ process {
     memory = {params.totalMemory}
   }
   $RunVEP {
-    memory = {params.totalMemory}
+    memory = {params.totalMemory}  // TODO Does VEP really require that much?
     errorStrategy = { task.exitStatus == 143 ? 'retry' : 'ignore' }
   }
 }


### PR DESCRIPTION
This cleans up the `localhost.config` file a bit:

The most important change is that the default is to request 1 cores and 8 GB of memory, and that the exceptions to that need to be configured. Before, the defaul twas to request 16 cores and the full memory of a node.

Also, I’ve set `maxForks = 16` for *all* processes. Nextflow will already make sure that the launched processes do not use more memory and CPU cores than available, so `cpus` and `memory` will already limit the number of launched processes at a time. One reason to use `maxForks` could be to reduce I/O, but this should not be relevant for this configuration where the pipeline runs on a single node.