### PR TITLE
Simplify operations on bedIntervals and intervals in general

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -726,7 +726,7 @@ bedIntervals = bedIntervals
   .map{duration, intervalFile -> intervalFile}
 
 if (verbose) bedIntervals = bedIntervals.view {
-  "Interv: ${it.fileName}"
+  "  Interv: ${it.baseName}"
 }
 
 (bamsNormalTemp, bamsNormal, bedIntervals) = generateIntervalsForVC(bamsNormal, bedIntervals)
@@ -778,7 +778,7 @@ process RunHaplotypecaller {
     ])
 
   output:
-    set val("gvcf-hc"), idPatient, idSample, idSample, val("${intervalBed.baseName}_${idSample}"), file("${intervalBed.baseName}_${idSample}.g.vcf") into hcGenomicVCF
+    set val("gvcf-hc"), idPatient, idSample, idSample, file("${intervalBed.baseName}_${idSample}.g.vcf") into hcGenomicVCF
     set idPatient, idSample, file(intervalBed), file("${intervalBed.baseName}_${idSample}.g.vcf") into vcfsToGenotype
 
   when: 'haplotypecaller' in tools
@@ -818,7 +818,7 @@ process RunGenotypeGVCFs {
     ])
 
   output:
-    set val("haplotypecaller"), idPatient, idSample, idSample, val("${intervalBed.baseName}_${idSample}"), file("${intervalBed.baseName}_${idSample}.vcf") into hcGenotypedVCF
+    set val("haplotypecaller"), idPatient, idSample, idSample, file("${intervalBed.baseName}_${idSample}.vcf") into hcGenotypedVCF
 
   when: 'haplotypecaller' in tools
 
@@ -854,7 +854,7 @@ process RunMutect1 {
     ])
 
   output:
-    set val("mutect1"), idPatient, idSampleNormal, idSampleTumor, val("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect1Output
+    set val("mutect1"), idPatient, idSampleNormal, idSampleTumor, file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect1Output
 
   when: 'mutect1' in tools
 
@@ -893,7 +893,7 @@ process RunMutect2 {
     ])
 
   output:
-    set val("mutect2"), idPatient, idSampleNormal, idSampleTumor, val("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect2Output
+    set val("mutect2"), idPatient, idSampleNormal, idSampleTumor, file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect2Output
 
   when: 'mutect2' in tools
 
@@ -923,7 +923,7 @@ process RunFreeBayes {
     file(genomeFile) from Channel.value(referenceMap.genomeFile)
 
   output:
-    set val("freebayes"), idPatient, idSampleNormal, idSampleTumor, val("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into freebayesOutput
+    set val("freebayes"), idPatient, idSampleNormal, idSampleTumor, file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into freebayesOutput
 
   when: 'freebayes' in tools
 
@@ -954,8 +954,7 @@ vcfsToMerge = hcGenomicVCF.mix(hcGenotypedVCF, mutect1Output, mutect2Output, fre
 if (verbose) vcfsToMerge = vcfsToMerge.view {
   "VCFs To be merged:\n\
   Tool  : ${it[0]}\tID    : ${it[1]}\tSample: [${it[3]}, ${it[2]}]\n\
-  Interv: ${it[4]}\n\
-  Files : ${it[5].fileName}"
+  Files : ${it[4].fileName}"
 }
 
 process ConcatVCF {
@@ -964,7 +963,7 @@ process ConcatVCF {
   publishDir "${directoryMap."$variantCaller"}", mode: 'copy'
 
   input:
-    set variantCaller, idPatient, idSampleNormal, idSampleTumor, tag, file(vcFiles) from vcfsToMerge
+    set variantCaller, idPatient, idSampleNormal, idSampleTumor, file(vcFiles) from vcfsToMerge
     file(genomeIndex) from Channel.value(referenceMap.genomeIndex)
 
   output:

--- a/main.nf
+++ b/main.nf
@@ -724,8 +724,7 @@ bedIntervals = bedIntervals
   .map{duration, intervalFile -> intervalFile}
 
 if (verbose) bedIntervals = bedIntervals.view {
-  "Interval:\n\
-  File  : ${it.fileName}"
+  "Interv: ${it.fileName}"
 }
 
 (bamsNormalTemp, bamsNormal, bedIntervals) = generateIntervalsForVC(bamsNormal, bedIntervals)

--- a/main.nf
+++ b/main.nf
@@ -709,9 +709,9 @@ process CreateIntervalBeds {
 
 bedIntervals = bedIntervals
   .map { intervalFile ->
-    duration = 0.0
+    final duration = 0.0
     for (line in intervalFile.readLines()) {
-      fields = line.split('\t')
+      final fields = line.split('\t')
       if (fields.size() >= 5) {
         duration += fields[4].toFloat()
       } else {

--- a/main.nf
+++ b/main.nf
@@ -707,7 +707,7 @@ process CreateIntervalBeds {
 
 bedIntervals = bedIntervals
   .map { path ->
-    name = path.getName()[0..-5] /* without .bed */
+    name = path.baseName
     duration = 0.0
     for (line in path.readLines()) {
       fields = line.split('\t')

--- a/main.nf
+++ b/main.nf
@@ -706,10 +706,9 @@ process CreateIntervalBeds {
 }
 
 bedIntervals = bedIntervals
-  .map { path ->
-    name = path.baseName
+  .map { intervalFile ->
     duration = 0.0
-    for (line in path.readLines()) {
+    for (line in intervalFile.readLines()) {
       fields = line.split('\t')
       if (fields.size() >= 5) {
         duration += fields[4].toFloat()
@@ -719,14 +718,14 @@ bedIntervals = bedIntervals
         duration += (end - start) / nucleotidesPerSecond
       }
     }
-    [duration, name, path]
+    [duration, intervalFile]
   }.toSortedList({ a, b -> b[0] <=> a[0] })
-  .flatten().collate(3)
-  .map{duration, name, path -> [name, path]}
+  .flatten().collate(2)
+  .map{duration, intervalFile -> intervalFile}
 
-if (verbose) bedIntervals = bedIntervals.view { name, path ->
+if (verbose) bedIntervals = bedIntervals.view {
   "Interval:\n\
-  Name  : $name\tFile  : ${path.fileName}"
+  File  : ${it.fileName}"
 }
 
 (bamsNormalTemp, bamsNormal, bedIntervals) = generateIntervalsForVC(bamsNormal, bedIntervals)
@@ -737,8 +736,8 @@ bamsFHC = bamsNormalTemp.mix(bamsTumorTemp)
 bedIntervals = bedIntervals.tap { intervalsTemp }
 recalTables = recalTables
   .spread(intervalsTemp)
-  .map { patient, sample, bam, bai, recalTable, intervalName, intervalBed ->
-    [patient, sample, bam, bai, intervalName, intervalBed, recalTable] }
+  .map { patient, sample, bam, bai, recalTable, intervalBed ->
+    [patient, sample, bam, bai, intervalBed, recalTable] }
 
 
 // re-associate the BAMs and samples with the recalibration table
@@ -765,10 +764,10 @@ bamsTumorNormalIntervals = bamsAll.spread(bedIntervals)
 
 
 process RunHaplotypecaller {
-  tag {idSample + "-" + intervalName}
+  tag {idSample + "-" + intervalBed.baseName}
 
   input:
-    set idPatient, idSample, file(bam), file(bai), intervalName, file(intervalBed), recalTable from bamsFHC //Are these values `ped to bamNormal already?
+    set idPatient, idSample, file(bam), file(bai), file(intervalBed), recalTable from bamsFHC //Are these values `ped to bamNormal already?
     set file(genomeFile), file(genomeIndex), file(genomeDict), file(dbsnp), file(dbsnpIndex) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
@@ -778,8 +777,8 @@ process RunHaplotypecaller {
     ])
 
   output:
-    set val("gvcf-hc"), idPatient, idSample, idSample, val("${intervalName}_${idSample}"), file("${intervalName}_${idSample}.g.vcf") into hcGenomicVCF
-    set idPatient, idSample, intervalName, file(intervalBed), file("${intervalName}_${idSample}.g.vcf") into vcfsToGenotype
+    set val("gvcf-hc"), idPatient, idSample, idSample, val("${intervalBed.baseName}_${idSample}"), file("${intervalBed.baseName}_${idSample}.g.vcf") into hcGenomicVCF
+    set idPatient, idSample, file(intervalBed), file("${intervalBed.baseName}_${idSample}.g.vcf") into vcfsToGenotype
 
   when: 'haplotypecaller' in tools
 
@@ -797,7 +796,7 @@ process RunHaplotypecaller {
   -I $bam \
   -L $intervalBed \
   --disable_auto_index_creation_and_locking_when_reading_rods \
-  -o ${intervalName}_${idSample}.g.vcf
+  -o ${intervalBed.baseName}_${idSample}.g.vcf
   """
 }
 hcGenomicVCF = hcGenomicVCF.groupTuple(by:[0,1,2,3])
@@ -805,10 +804,10 @@ hcGenomicVCF = hcGenomicVCF.groupTuple(by:[0,1,2,3])
 if (!gvcf) {hcGenomicVCF.close()}
 
 process RunGenotypeGVCFs {
-  tag {idSample + "-" + intervalName}
+  tag {idSample + "-" + intervalBed.baseName}
 
   input:
-    set idPatient, idSample, intervalName, file(intervalBed), file(gvcf) from vcfsToGenotype
+    set idPatient, idSample, file(intervalBed), file(gvcf) from vcfsToGenotype
     set file(genomeFile), file(genomeIndex), file(genomeDict), file(dbsnp), file(dbsnpIndex) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
@@ -818,7 +817,7 @@ process RunGenotypeGVCFs {
     ])
 
   output:
-    set val("haplotypecaller"), idPatient, idSample, idSample, val("${intervalName}_${idSample}"), file("${intervalName}_${idSample}.vcf") into hcGenotypedVCF
+    set val("haplotypecaller"), idPatient, idSample, idSample, val("${intervalBed.baseName}_${idSample}"), file("${intervalBed.baseName}_${idSample}.vcf") into hcGenotypedVCF
 
   when: 'haplotypecaller' in tools
 
@@ -833,16 +832,16 @@ process RunGenotypeGVCFs {
   --dbsnp $dbsnp \
   --variant $gvcf \
   --disable_auto_index_creation_and_locking_when_reading_rods \
-  -o ${intervalName}_${idSample}.vcf
+  -o ${intervalBed.baseName}_${idSample}.vcf
   """
 }
 hcGenotypedVCF = hcGenotypedVCF.groupTuple(by:[0,1,2,3])
 
 process RunMutect1 {
-  tag {idSampleTumor + "_vs_" + idSampleNormal + "-" + intervalName}
+  tag {idSampleTumor + "_vs_" + idSampleNormal + "-" + intervalBed.baseName}
 
   input:
-    set idPatient, idSampleNormal, file(bamNormal), file(baiNormal), idSampleTumor, file(bamTumor), file(baiTumor), intervalName, file(intervalBed) from bamsFMT1
+    set idPatient, idSampleNormal, file(bamNormal), file(baiNormal), idSampleTumor, file(bamTumor), file(baiTumor), file(intervalBed) from bamsFMT1
     set file(genomeFile), file(genomeIndex), file(genomeDict), file(dbsnp), file(dbsnpIndex), file(cosmic), file(cosmicIndex) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
@@ -854,7 +853,7 @@ process RunMutect1 {
     ])
 
   output:
-    set val("mutect1"), idPatient, idSampleNormal, idSampleTumor, val("${intervalName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect1Output
+    set val("mutect1"), idPatient, idSampleNormal, idSampleTumor, val("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect1Output
 
   when: 'mutect1' in tools
 
@@ -870,18 +869,18 @@ process RunMutect1 {
   -I:tumor $bamTumor \
   -L $intervalBed \
   --disable_auto_index_creation_and_locking_when_reading_rods \
-  --out ${intervalName}_${idSampleTumor}_vs_${idSampleNormal}.call_stats.out \
-  --vcf ${intervalName}_${idSampleTumor}_vs_${idSampleNormal}.vcf
+  --out ${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.call_stats.out \
+  --vcf ${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf
   """
 }
 
 mutect1Output = mutect1Output.groupTuple(by:[0,1,2,3])
 
 process RunMutect2 {
-  tag {idSampleTumor + "_vs_" + idSampleNormal + "-" + intervalName}
+  tag {idSampleTumor + "_vs_" + idSampleNormal + "-" + intervalBed.baseName}
 
   input:
-    set idPatient, idSampleNormal, file(bamNormal), file(baiNormal), idSampleTumor, file(bamTumor), file(baiTumor), intervalName, file(intervalBed) from bamsFMT2
+    set idPatient, idSampleNormal, file(bamNormal), file(baiNormal), idSampleTumor, file(bamTumor), file(baiTumor), file(intervalBed) from bamsFMT2
     set file(genomeFile), file(genomeIndex), file(genomeDict), file(dbsnp), file(dbsnpIndex), file(cosmic), file(cosmicIndex) from Channel.value([
       referenceMap.genomeFile,
       referenceMap.genomeIndex,
@@ -893,7 +892,7 @@ process RunMutect2 {
     ])
 
   output:
-    set val("mutect2"), idPatient, idSampleNormal, idSampleTumor, val("${intervalName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect2Output
+    set val("mutect2"), idPatient, idSampleNormal, idSampleTumor, val("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into mutect2Output
 
   when: 'mutect2' in tools
 
@@ -909,21 +908,21 @@ process RunMutect2 {
   -I:tumor $bamTumor \
   --disable_auto_index_creation_and_locking_when_reading_rods \
   -L $intervalBed \
-  -o ${intervalName}_${idSampleTumor}_vs_${idSampleNormal}.vcf
+  -o ${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf
   """
 }
 
 mutect2Output = mutect2Output.groupTuple(by:[0,1,2,3])
 
 process RunFreeBayes {
-  tag {idSampleTumor + "_vs_" + idSampleNormal + "-" + intervalName}
+  tag {idSampleTumor + "_vs_" + idSampleNormal + "-" + intervalBed.baseName}
 
   input:
-    set idPatient, idSampleNormal, file(bamNormal), file(baiNormal), idSampleTumor, file(bamTumor), file(baiTumor), intervalName, file(intervalBed) from bamsFFB
+    set idPatient, idSampleNormal, file(bamNormal), file(baiNormal), idSampleTumor, file(bamTumor), file(baiTumor), file(intervalBed) from bamsFFB
     file(genomeFile) from Channel.value(referenceMap.genomeFile)
 
   output:
-    set val("freebayes"), idPatient, idSampleNormal, idSampleTumor, val("${intervalName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into freebayesOutput
+    set val("freebayes"), idPatient, idSampleNormal, idSampleTumor, val("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}"), file("${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf") into freebayesOutput
 
   when: 'freebayes' in tools
 
@@ -941,7 +940,7 @@ process RunFreeBayes {
     --min-alternate-count 2 \
     -t $intervalBed \
     $bamTumor \
-    $bamNormal > ${intervalName}_${idSampleTumor}_vs_${idSampleNormal}.vcf
+    $bamNormal > ${intervalBed.baseName}_${idSampleTumor}_vs_${idSampleNormal}.vcf
   """
 }
 

--- a/main.nf
+++ b/main.nf
@@ -667,6 +667,8 @@ bamsTumor = bamsTumor.map { idPatient, status, idSample, bam, bai -> [idPatient,
 // from the "1:1-2000" string make ["1:1-2000","1_1-2000"]
 
 process CreateIntervalBeds {
+  tag {intervals.fileName}
+
   input:
     file(intervals) from Channel.value(referenceMap.intervals)
 


### PR DESCRIPTION
- remove name of intervals
- use file.baseName to get the string
- remove unnecessary variables that were passed through ConcatVCF and never used anywhere