### PR TITLE
Updates

### DIFF
--- a/configuration/genomes.config
+++ b/configuration/genomes.config
@@ -22,19 +22,13 @@ params {
       cosmicIndex = "${cosmic}.idx"
       dbsnp       = "$bundleDir/dbsnp_138.b37.vcf"
       dbsnpIndex  = "${dbsnp}.idx"
-      genome      = "$bundleDir/human_g1k_v37_decoy.fasta"
-      bwaIndex    = "${genome}.{amb,ann,bwt,pac,sa}"
+      genomeFile  = "$bundleDir/human_g1k_v37_decoy.fasta"
+      bwaIndex    = "${genomeFile}.{amb,ann,bwt,pac,sa}"
       genomeDict  = "$bundleDir/human_g1k_v37_decoy.dict"
-      genomeIndex = "${genome}.fai"
+      genomeIndex = "${genomeFile}.fai"
       intervals   = "$bundleDir/wgs_calling_regions_CAW.list"
-      knownIndels = [
-        "$bundleDir/1000G_phase1.indels.b37.vcf",
-        "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf"
-      ]
-      knownIndelsIndex = [
-        "$bundleDir/1000G_phase1.indels.b37.vcf.idx",
-        "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.vcf.idx"
-      ]
+      knownIndels = "$bundleDir/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.vcf"
+      knownIndelsIndex = "$bundleDir/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.vcf.idx"
       snpeffDb    = "GRCh37.75"
     }
     'GRCh38' {
@@ -44,19 +38,13 @@ params {
       cosmicIndex   = "${cosmic}.idx"
       dbsnp         = "$bundleDir/dbsnp_146.hg38.vcf.gz"
       dbsnpIndex    = "${dbsnp}.tbi"
-      genome        = "$bundleDir/Homo_sapiens_assembly38.fasta"
+      genomeFile    = "$bundleDir/Homo_sapiens_assembly38.fasta"
       genomeDict    = "$bundleDir/Homo_sapiens_assembly38.dict"
-      genomeIndex   = "${genome}.fai"
-      bwaIndex      = "${genome}.64.{amb,ann,bwt,pac,sa,alt}"
+      genomeIndex   = "${genomeFile}.fai"
+      bwaIndex      = "${genomeFile}.64.{amb,ann,bwt,pac,sa,alt}"
       intervals     = "$bundleDir/wgs_calling_regions.hg38.bed"
-      knownIndels   = [
-        "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz",
-        "$bundleDir/beta/Homo_sapiens_assembly38.known_indels.vcf.gz"
-      ]
-      knownIndelsIndex = [
-        "$bundleDir/Mills_and_1000G_gold_standard.indels.hg38.vcf.gz.tbi",
-        "$bundleDir/beta/Homo_sapiens_assembly38.known_indels.vcf.gz.tbi"
-      ]
+      knownIndels   = "$bundleDir/{Mills_and_1000G_gold_standard.indels.hg38,beta/Homo_sapiens_assembly38.known_indels}.vcf.gz"
+      knownIndelsIndex = "$bundleDir/{Mills_and_1000G_gold_standard.indels.hg38,beta/Homo_sapiens_assembly38.known_indels}.vcf.gz.tbi"
       snpeffDb      = "GRCh38.86"
     }
     'smallGRCh37' {
@@ -66,19 +54,13 @@ params {
       cosmicIndex = "${cosmic}.idx"
       dbsnp       = "$bundleDir/dbsnp_138.b37.small.vcf"
       dbsnpIndex  = "${dbsnp}.idx"
-      genome      = "$bundleDir/human_g1k_v37_decoy.small.fasta"
-      bwaIndex    = "${genome}.{amb,ann,bwt,pac,sa}"
+      genomeFile  = "$bundleDir/human_g1k_v37_decoy.small.fasta"
+      bwaIndex    = "${genomeFile}.{amb,ann,bwt,pac,sa}"
       genomeDict  = "$bundleDir/human_g1k_v37_decoy.small.dict"
-      genomeIndex = "${genome}.fai"
+      genomeIndex = "${genomeFile}.fai"
       intervals   = "$bundleDir/small.intervals"
-      knownIndels = [
-        "$bundleDir/1000G_phase1.indels.b37.small.vcf",
-        "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.small.vcf"
-      ]
-      knownIndelsIndex = [
-        "$bundleDir/1000G_phase1.indels.b37.small.vcf.idx",
-        "$bundleDir/Mills_and_1000G_gold_standard.indels.b37.small.vcf"
-      ]
+      knownIndels = "$bundleDir/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.small.vcf"
+      knownIndelsIndex = "$bundleDir/{1000G_phase1,Mills_and_1000G_gold_standard}.indels.b37.small.vcf.idx"
       snpeffDb    = "GRCh37.75"
     }
   }

--- a/main.nf
+++ b/main.nf
@@ -659,12 +659,6 @@ bamsTumor = bamsTumor.map { idPatient, status, idSample, bam, bai -> [idPatient,
 // Do variant calling by this intervals, and re-merge the VCFs.
 // Since we are on a cluster, this can parallelize the variant call processes.
 // And push down the variant call wall clock time significanlty.
-// In fact we need two channels: one for the actual genomic region
-// and an other for names without ":"
-// as nextflow is not happy with them (will report as a failed process).
-// For region 1:1-2000 the output file name will be something like:
-// 1_1-2000_Sample_name.xxx.vcf
-// from the "1:1-2000" string make ["1:1-2000","1_1-2000"]
 
 process CreateIntervalBeds {
   tag {intervals.fileName}

--- a/main.nf
+++ b/main.nf
@@ -29,15 +29,19 @@ kate: syntax groovy; space-indent on; indent-width 2;
 --------------------------------------------------------------------------------
  Processes overview
  - RunFastQC - Run FastQC for QC on fastq files
- - MapReads - Map reads
+ - MapReads - Map reads with BWA
  - MergeBams - Merge BAMs if multilane samples
- - MarkDuplicates - Mark Duplicates
+ - MarkDuplicates - Mark Duplicates with Picard
  - RealignerTargetCreator - Create realignment target intervals
  - IndelRealigner - Realign BAMs as T/N pair
- - CreateRecalibrationTable - Create Recalibration Table
- - RecalibrateBam - Recalibrate Bam
+ - CreateRecalibrationTable - Create Recalibration Table with BaseRecalibrator
+ - RecalibrateBam - Recalibrate Bam with PrintReads
  - RunSamtoolsStats - Run Samtools stats on recalibrated BAM files
+ - RunBamQC - Run qualimap BamQC on recalibrated BAM files
+ - CreateIntervalBeds - Create and sort intervals into bed files
  - RunHaplotypecaller - Run HaplotypeCaller for GermLine Variant Calling (Parallelized processes)
+ - RunGenotypeGVCFs - Run HaplotypeCaller for GermLine Variant Calling (Parallelized processes)
+ - RunBcftoolsStats - Run BCFTools stats on vcf before annotation
  - RunMutect1 - Run MuTect1 for Variant Calling (Parallelized processes)
  - RunMutect2 - Run MuTect2 for Variant Calling (Parallelized processes)
  - RunFreeBayes - Run FreeBayes for Variant Calling (Parallelized processes)
@@ -59,19 +63,11 @@ kate: syntax groovy; space-indent on; indent-width 2;
 
 version = '1.1'
 
-if (!isAllowedParams(params)) {exit 1, "params is unknown, see --help for more information"}
+if (params.help) exit 0, helpMessage()
+if (params.version) exit 0, versionMessage()
+if (!isAllowedParams(params)) exit 1, "params is unknown, see --help for more information"
 
-if (params.help) {
-  helpMessage()
-  exit 1
-}
-
-if (params.version) {
-  versionMessage()
-  exit 1
-}
-
-if (!checkUppmaxProject()) {exit 1, 'No UPPMAX project ID found! Use --project <UPPMAX Project ID>'}
+if (!checkUppmaxProject()) exit 1, "No UPPMAX project ID found! Use --project <UPPMAX Project ID>"
 
 step = params.step.toLowerCase()
 if (step == 'preprocessing') step = 'mapping'
@@ -1504,20 +1500,45 @@ def checkParameterList(list, realList) {
   return list.every{ checkParameterExistence(it, realList) }
 }
 
+def checkParamReturnFile(item) {
+  params."$item" = params.genomes[params.genome]."$item"
+  return file(params."$item")
+}
+
 def checkParams(it) {
   // Check if params is in this given list
   return it in [
+    'acLoci',
+    'ac-loci',
     'annotate-tools',
     'annotate-VCF',
     'annotateTools',
     'annotateVCF',
+    'bwaIndex',
+    'bwa-index',
     'call-name',
     'callName',
     'contact-mail',
     'contactMail',
+    'cosmic',
+    'cosmicIndex',
+    'cosmic-index',
+    'dbsnp',
+    'dbsnp-index',
     'genome',
+    'genomeDict',
+    'genome-dict',
+    'genomeFile',
+    'genome-file',
+    'genomeIndex',
+    'genome-index',
     'genomes',
     'help',
+    'intervals',
+    'knownIndels',
+    'known-indels',
+    'knownIndelsIndex',
+    'known-indels-index',
     'no-GVCF',
     'no-reports',
     'noGVCF',
@@ -1602,23 +1623,27 @@ def defineReferenceMap() {
   if (!(params.genome in params.genomes)) {
     exit 1, "Genome $params.genome not found in configuration"
   }
-  genome = params.genomes[params.genome]
-
   return [
-    'acLoci'      : file(genome.acLoci),  // loci file for ascat
-    'dbsnp'       : file(genome.dbsnp),
-    'dbsnpIndex'  : file(genome.dbsnpIndex),
-    'cosmic'      : file(genome.cosmic),  // cosmic VCF with VCF4.1 header
-    'cosmicIndex' : file(genome.cosmicIndex),
-    'genomeDict'  : file(genome.genomeDict),  // genome reference dictionary
-    'genomeFile'  : file(genome.genome),  // FASTA genome reference
-    'genomeIndex' : file(genome.genomeIndex),  // genome .fai file
-    'bwaIndex'    : file(genome.bwaIndex),  // BWA index files
-    // intervals file for spread-and-gather processes (usually chromosome chunks at centromeres)
-    'intervals'   : file(genome.intervals),
+    // loci file for ascat
+    'acLoci'           : checkParamReturnFile("acLoci"),
+    'dbsnp'            : checkParamReturnFile("dbsnp"),
+    'dbsnpIndex'       : checkParamReturnFile("dbsnpIndex"),
+    // cosmic VCF with VCF4.1 header
+    'cosmic'           : checkParamReturnFile("cosmic"),
+    'cosmicIndex'      : checkParamReturnFile("cosmicIndex"),
+    // genome reference dictionary
+    'genomeDict'       : checkParamReturnFile("genomeDict"),
+    // FASTA genome reference
+    'genomeFile'       : checkParamReturnFile("genomeFile"),
+    // genome .fai file
+    'genomeIndex'      : checkParamReturnFile("genomeIndex"),
+    // BWA index files
+    'bwaIndex'         : checkParamReturnFile("bwaIndex"),
+    // intervals file for spread-and-gather processes
+    'intervals'        : checkParamReturnFile("intervals"),
     // VCFs with known indels (such as 1000 Genomes, Mill’s gold standard)
-    'knownIndels' : genome.knownIndels.collect{file(it)},
-    'knownIndelsIndex': genome.knownIndelsIndex.collect{file(it)},
+    'knownIndels'      : checkParamReturnFile("knownIndels"),
+    'knownIndelsIndex' : checkParamReturnFile("knownIndelsIndex"),
   ]
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3,16 +3,16 @@ TOOL="all"
 
 while [[ $# -gt 1 ]]
 do
-    key="$1"
-    case $key in
-        -t|--tool)
-        TOOL="$2"
-        shift
-        ;;
-        *) # unknown option
-        ;;
-    esac
+  key="$1"
+  case $key in
+    -t|--tool)
+    TOOL="$2"
     shift
+    ;;
+    *) # unknown option
+    ;;
+  esac
+  shift
 done
 
 # Install Nextflow

--- a/scripts/runMantaOnStratch.sh
+++ b/scripts/runMantaOnStratch.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -xl
-#SBATCH -A sens2016004
-#SBATCH -p node
-#SBATCH -t 168:00:00
-module load Nextflow
-export NXF_TEMP=/scratch
-export NXF_LAUNCHBASE=/scratch
-export NXF_WORK=/scratch
-nextflow run /home/szilva/CAW/main.nf -c /home/szilva/CAW/nextflow.config -profile localhost --project sens2016004 --verbose --steps skipPreprocessing,Manta --sample Preprocessing/Recalibrated/recalibrated.tsv

--- a/scripts/runPreprocessingOnScratch.sh
+++ b/scripts/runPreprocessingOnScratch.sh
@@ -1,9 +1,0 @@
-#!/bin/bash -xl
-#SBATCH -A sens2016004
-#SBATCH -p node
-#SBATCH -t 168:00:00
-module load Nextflow
-export NXF_TEMP=/scratch
-export NXF_LAUNCHBASE=/scratch
-export NXF_WORK=/scratch
-nextflow run ${HOME}/CAW/main.nf -c ${HOME}/CAW/nextflow.config --project sens2016004 --step preprocessing --sample $1


### PR DESCRIPTION
- `params.genomes[genome].genome` is now `params.genomes[genome].genomeFile` for more coherence and to avoid confusion.
- `knownIndels` and `knownIndelsIndex` are now defined with curly bracket instead of a list, again for more coherence with other reference files like `bwaIndex`
- remove some comments
- add new `checkParamReturnFile()` function that with a given `item` will check if a `params."$item"` exists, if not, will give it the value `params.genomes[genome]."$item"` and will return the file corresponding: `file(params."$item")`. That gives us back the possibility to specify different reference files.
- remove old skeleton scripts