### PR TITLE
Reduce ConcatVCF resources to sane levels

### DIFF
--- a/configuration/uppmax-localhost.config
+++ b/configuration/uppmax-localhost.config
@@ -58,6 +58,9 @@ process {
 
   $ConcatVCF {
     cpus = 8
+    // For unknown reasons, ConcatVCF sometimes fails with SIGPIPE
+    // (exit code 141). Rerunning the process will usually work.
+    errorStrategy = {task.exitStatus == 141 ? 'retry' : 'terminate'}
   }
   $CreateRecalibrationTable {
     cpus = 16

--- a/configuration/uppmax-localhost.config
+++ b/configuration/uppmax-localhost.config
@@ -57,8 +57,7 @@ process {
   // These processes are defined in main.nf
 
   $ConcatVCF {
-    cpus = 16
-    memory = {params.totalMemory}
+    cpus = 8
   }
   $CreateRecalibrationTable {
     cpus = 16


### PR DESCRIPTION
ConcatVCF does not need much memory and giving it more than 8 cores
does not make it faster.