### PR TITLE
Write an error message when --sampleDir does not find any FASTQ files

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -176,6 +176,12 @@ if (tsvPath) {
 } else if (params.sampleDir) {
   if (step != 'mapping') exit 1, '--sampleDir does not support steps other than "mapping"'
   fastqFiles = extractFastqFromDir(params.sampleDir)
+  (fastqFiles, fastqTmp) = fastqFiles.into(2)
+  fastqTmp.toList().subscribe onNext: {
+    if (it.size() == 0) {
+      exit 1, "No FASTQ files found in --sampleDir directory '${params.sampleDir}'"
+    }
+  }
   tsvFile = params.sampleDir  // used in the reports
 } else if (step != 'annotate') exit 1, 'No sample were defined, see --help'
 


### PR DESCRIPTION
Closes #454 

I would have liked to use `Channel.isEmpty()` because it has such an obvious name, but it is unclear to me how that would work.